### PR TITLE
LMS Remove createMessageChannel from the Intellisense

### DIFF
--- a/packages/lightning-lsp-common/src/resources/sfdx/typings/messageservice.d.ts
+++ b/packages/lightning-lsp-common/src/resources/sfdx/typings/messageservice.d.ts
@@ -29,12 +29,6 @@ declare module 'lightning/messageService' {
      */
     export function unsubscribe(subscription: Object): void;
     /**
-     * Creates an anonymous MessageChannel object for use with Message Service.
-     *
-     * @return {Object} - Anonymous MessageChannel.
-     */
-    export function createMessageChannel(): Object;
-    /**
      * Creates a message context for an LWC library.
      *
      * @return {Object} - MessageContext for use by LWC Library.

--- a/packages/lwc-language-server/src/metadata-utils/__tests__/message-channel-util.test.ts
+++ b/packages/lwc-language-server/src/metadata-utils/__tests__/message-channel-util.test.ts
@@ -47,12 +47,6 @@ it('indexMessageChannels', async done => {
      */
     export function unsubscribe(subscription: Object): void;
     /**
-     * Creates an anonymous MessageChannel object for use with Message Service.
-     *
-     * @return {Object} - Anonymous MessageChannel.
-     */
-    export function createMessageChannel(): Object;
-    /**
      * Creates a message context for an LWC library.
      *
      * @return {Object} - MessageContext for use by LWC Library.


### PR DESCRIPTION
We don't want to add `createMessageChannel` to public docs right now as it's opening up usage of it when it really doesn't provide the pattern we want people to use. If they use `createMessageContext`,

1. the developer ergonomics aren't as great because now the developer has to explicitly export and pass around a reference to that channel
2. there's no namespace guarding or deploy time access checks

We can come up with the right story for when and how to talk about this API at a later time. For now it's mostly used internally and for some testing off core.