### PR TITLE
activate on the lwc-services dependency

### DIFF
--- a/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
@@ -87,6 +87,42 @@ describe('detectWorkspaceType', () => {
         expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
     });
 
+    test('when package.json dependencies include lwc-services, workspaceType is STANDARD_LWC', () => {
+        mockFs({
+            workspacedir: {
+                'package.json': JSON.stringify({
+                    dependencies: {
+                        'lwc-services': 1,
+                    },
+                }),
+            },
+        });
+
+        const workspaceType = detectWorkspaceType(['workspacedir']);
+
+        mockFs.restore();
+
+        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
+    });
+
+    test('when package.json devDependencies include lwc-services, workspaceType is STANDARD_LWC', () => {
+        mockFs({
+            workspacedir: {
+                'package.json': JSON.stringify({
+                    devDependencies: {
+                        'lwc-services': 1,
+                    },
+                }),
+            },
+        });
+
+        const workspaceType = detectWorkspaceType(['workspacedir']);
+
+        mockFs.restore();
+
+        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
+    });
+
     test('when package.json specifies workspaces, workspaceType is MONOREPO', () => {
         mockFs({
             workspacedir: {

--- a/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
@@ -30,6 +30,18 @@ describe('detectWorkspaceType', () => {
         expect(workspaceType).toEqual(WorkspaceType.SFDX);
     });
 
+    test('when an lwc.config.js file is present, workspaceType is STANDARD_LWC', () => {
+        mockFs({
+            workspacedir: {
+                'lwc.config.js': '',
+            },
+        });
+
+        const workspaceType = detectWorkspaceType(['workspacedir']);
+
+        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
+    });
+
     test('when workspace-user.xml file is present at the root, workspaceType is CORE_ALL', () => {
         mockFs({
             workspacedir: {

--- a/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
@@ -112,8 +112,6 @@ describe('detectWorkspaceType', () => {
 
         const workspaceType = detectWorkspaceType(['workspacedir']);
 
-        mockFs.restore();
-
         expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
     });
 
@@ -129,8 +127,6 @@ describe('detectWorkspaceType', () => {
         });
 
         const workspaceType = detectWorkspaceType(['workspacedir']);
-
-        mockFs.restore();
 
         expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
     });

--- a/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
@@ -143,7 +143,7 @@ describe('detectWorkspaceType', () => {
         expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
     });
 
-    test('when package.json has any dependency that starts with "@lwc"', () => {
+    test('when package.json has the `lwc-services` dependency', () => {
         mockFs({
             workspacedir: {
                 'package.json': JSON.stringify({

--- a/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
@@ -81,6 +81,53 @@ describe('detectWorkspaceType', () => {
         expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
     });
 
+    test('when package.json dependencies includes @lwc/<anything>, workspaceType is STANDARD_LWC', () => {
+        mockFs({
+            workspacedir: {
+                'package.json': JSON.stringify({
+                    dependencies: {
+                        '@lwc/compiler': 1,
+                    },
+                }),
+            },
+        });
+
+        const workspaceType = detectWorkspaceType(['workspacedir']);
+
+        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
+    });
+
+    test('when package.json devDependencies includes @lwc/<anything>, workspaceType is STANDARD_LWC', () => {
+        mockFs({
+            workspacedir: {
+                'package.json': JSON.stringify({
+                    devDependencies: {
+                        '@lwc/compiler': 1,
+                    },
+                }),
+            },
+        });
+
+        const workspaceType = detectWorkspaceType(['workspacedir']);
+
+        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
+    });
+    test('when package.json dependencies includes @lwc/engine, workspaceType is STANDARD_LWC', () => {
+        mockFs({
+            workspacedir: {
+                'package.json': JSON.stringify({
+                    dependencies: {
+                        '@lwc/engine': 1,
+                    },
+                }),
+            },
+        });
+
+        const workspaceType = detectWorkspaceType(['workspacedir']);
+
+        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
+    });
+
     test('when package.json devDependencies include @lwc/engine, workspaceType is STANDARD_LWC', () => {
         mockFs({
             workspacedir: {
@@ -93,9 +140,21 @@ describe('detectWorkspaceType', () => {
         });
 
         const workspaceType = detectWorkspaceType(['workspacedir']);
+        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
+    });
 
-        mockFs.restore();
+    test('when package.json has any dependency that starts with "@lwc"', () => {
+        mockFs({
+            workspacedir: {
+                'package.json': JSON.stringify({
+                    dependencies: {
+                        'lwc-services': 1,
+                    },
+                }),
+            },
+        });
 
+        const workspaceType = detectWorkspaceType(['workspacedir']);
         expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
     });
 

--- a/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
@@ -143,12 +143,28 @@ describe('detectWorkspaceType', () => {
         expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
     });
 
-    test('when package.json has the `lwc-services` dependency', () => {
+    test('when package.json dependencies includes `lwc`, workspaceType is STANDARD_LWC', () => {
         mockFs({
             workspacedir: {
                 'package.json': JSON.stringify({
                     dependencies: {
-                        'lwc-services': 1,
+                        lwc: 1,
+                    },
+                }),
+            },
+        });
+
+        const workspaceType = detectWorkspaceType(['workspacedir']);
+
+        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
+    });
+
+    test('when package.json devDependencies include `lwc`, workspaceType is STANDARD_LWC', () => {
+        mockFs({
+            workspacedir: {
+                'package.json': JSON.stringify({
+                    devDependencies: {
+                        lwc: 1,
                     },
                 }),
             },

--- a/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
@@ -158,6 +158,22 @@ describe('detectWorkspaceType', () => {
         expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
     });
 
+    test('when package.json has `lwc` configuration', () => {
+        mockFs({
+            workspacedir: {
+                'package.json': JSON.stringify({
+                    lwc: {
+                        mapNamespaceFromPath: true,
+                        modules: ['src/main/modules'],
+                    },
+                }),
+            },
+        });
+
+        const workspaceType = detectWorkspaceType(['workspacedir']);
+        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
+    });
+
     test('when package.json dependencies include lwc-services, workspaceType is STANDARD_LWC', () => {
         mockFs({
             workspacedir: {

--- a/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
@@ -190,38 +190,6 @@ describe('detectWorkspaceType', () => {
         expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
     });
 
-    test('when package.json dependencies include lwc-services, workspaceType is STANDARD_LWC', () => {
-        mockFs({
-            workspacedir: {
-                'package.json': JSON.stringify({
-                    dependencies: {
-                        'lwc-services': 1,
-                    },
-                }),
-            },
-        });
-
-        const workspaceType = detectWorkspaceType(['workspacedir']);
-
-        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
-    });
-
-    test('when package.json devDependencies include lwc-services, workspaceType is STANDARD_LWC', () => {
-        mockFs({
-            workspacedir: {
-                'package.json': JSON.stringify({
-                    devDependencies: {
-                        'lwc-services': 1,
-                    },
-                }),
-            },
-        });
-
-        const workspaceType = detectWorkspaceType(['workspacedir']);
-
-        expect(workspaceType).toEqual(WorkspaceType.STANDARD_LWC);
-    });
-
     test('when package.json specifies workspaces, workspaceType is MONOREPO', () => {
         mockFs({
             workspacedir: {

--- a/packages/lightning-lsp-common/src/shared.ts
+++ b/packages/lightning-lsp-common/src/shared.ts
@@ -98,13 +98,6 @@ export function detectWorkspaceHelper(root: string): WorkspaceType {
                 return WorkspaceType.STANDARD_LWC;
             }
 
-            // has a lwc-services dependency (this ca be removed once the
-            // `lwc.config.js` becomes required
-            if (allDependencies.includes('lwc-services')) {
-                // has
-                return WorkspaceType.STANDARD_LWC;
-            }
-
             if (packageInfo.workspaces) {
                 return WorkspaceType.MONOREPO;
             }

--- a/packages/lightning-lsp-common/src/shared.ts
+++ b/packages/lightning-lsp-common/src/shared.ts
@@ -84,7 +84,9 @@ export function detectWorkspaceHelper(root: string): WorkspaceType {
             const dependencies = Object.keys(packageInfo.dependencies || {});
             const devDependencies = Object.keys(packageInfo.devDependencies || {});
             const allDependencies = [...dependencies, ...devDependencies];
-            const hasLWCdependencies = allDependencies.some(key => key.includes('@lwc/'));
+            const hasLWCdependencies = allDependencies.some(key => {
+                return key.startsWith('@lwc/') || key === 'lwc';
+            });
 
             // any type of @lwc is a dependency
             if (hasLWCdependencies) {

--- a/packages/lightning-lsp-common/src/shared.ts
+++ b/packages/lightning-lsp-common/src/shared.ts
@@ -80,18 +80,26 @@ export function detectWorkspaceHelper(root: string): WorkspaceType {
     const packageJson = path.join(root, 'package.json');
     if (fs.existsSync(packageJson)) {
         try {
-            // Check if package.json contains @lwc/engine
             const packageInfo = JSON.parse(fs.readFileSync(packageJson, 'utf-8'));
             const dependencies = Object.keys(packageInfo.dependencies || {});
             const devDependencies = Object.keys(packageInfo.devDependencies || {});
             const allDependencies = [...dependencies, ...devDependencies];
             const hasLWCdependencies = allDependencies.some(key => key.includes('@lwc/'));
 
+            // any type of @lwc is a dependency
             if (hasLWCdependencies) {
                 return WorkspaceType.STANDARD_LWC;
             }
 
+            // has and type of lwc configuration
+            if (packageInfo.lwc) {
+                return WorkspaceType.STANDARD_LWC;
+            }
+
+            // has a lwc-services dependency (this ca be removed once the
+            // `lwc.config.js` becomes required
             if (allDependencies.includes('lwc-services')) {
+                // has
                 return WorkspaceType.STANDARD_LWC;
             }
 

--- a/packages/lightning-lsp-common/src/shared.ts
+++ b/packages/lightning-lsp-common/src/shared.ts
@@ -73,6 +73,10 @@ export function detectWorkspaceHelper(root: string): WorkspaceType {
         return WorkspaceType.CORE_PARTIAL;
     }
 
+    if (fs.existsSync(path.join(root, 'lwc.config.js'))) {
+        return WorkspaceType.STANDARD_LWC;
+    }
+
     const packageJson = path.join(root, 'package.json');
     if (fs.existsSync(packageJson)) {
         try {

--- a/packages/lightning-lsp-common/src/shared.ts
+++ b/packages/lightning-lsp-common/src/shared.ts
@@ -83,19 +83,26 @@ export function detectWorkspaceHelper(root: string): WorkspaceType {
             // Check if package.json contains @lwc/engine
             const packageInfo = JSON.parse(fs.readFileSync(packageJson, 'utf-8'));
             const dependencies = Object.keys(packageInfo.dependencies || {});
-            if (dependencies.includes('@lwc/engine') || dependencies.includes('lwc-services')) {
-                return WorkspaceType.STANDARD_LWC;
-            }
             const devDependencies = Object.keys(packageInfo.devDependencies || {});
-            if (devDependencies.includes('@lwc/engine') || devDependencies.includes('lwc-services')) {
+            const allDependencies = [...dependencies, ...devDependencies];
+            const hasLWCdependencies = allDependencies.some(key => key.includes('@lwc/'));
+
+            if (hasLWCdependencies) {
                 return WorkspaceType.STANDARD_LWC;
             }
+
+            if (allDependencies.includes('lwc-services')) {
+                return WorkspaceType.STANDARD_LWC;
+            }
+
             if (packageInfo.workspaces) {
                 return WorkspaceType.MONOREPO;
             }
+
             if (fs.existsSync(path.join(root, 'lerna.json'))) {
                 return WorkspaceType.MONOREPO;
             }
+
             return WorkspaceType.STANDARD;
         } catch (e) {
             // Log error and fallback to setting workspace type to Unknown

--- a/packages/lightning-lsp-common/src/shared.ts
+++ b/packages/lightning-lsp-common/src/shared.ts
@@ -91,7 +91,7 @@ export function detectWorkspaceHelper(root: string): WorkspaceType {
                 return WorkspaceType.STANDARD_LWC;
             }
 
-            // has and type of lwc configuration
+            // has any type of lwc configuration
             if (packageInfo.lwc) {
                 return WorkspaceType.STANDARD_LWC;
             }

--- a/packages/lightning-lsp-common/src/shared.ts
+++ b/packages/lightning-lsp-common/src/shared.ts
@@ -79,11 +79,11 @@ export function detectWorkspaceHelper(root: string): WorkspaceType {
             // Check if package.json contains @lwc/engine
             const packageInfo = JSON.parse(fs.readFileSync(packageJson, 'utf-8'));
             const dependencies = Object.keys(packageInfo.dependencies || {});
-            if (dependencies.includes('@lwc/engine')) {
+            if (dependencies.includes('@lwc/engine') || dependencies.includes('lwc-services')) {
                 return WorkspaceType.STANDARD_LWC;
             }
             const devDependencies = Object.keys(packageInfo.devDependencies || {});
-            if (devDependencies.includes('@lwc/engine')) {
+            if (devDependencies.includes('@lwc/engine') || devDependencies.includes('lwc-services')) {
                 return WorkspaceType.STANDARD_LWC;
             }
             if (packageInfo.workspaces) {


### PR DESCRIPTION
### What does this PR do?

We're now checking the following cases to determine if a workspace
should be STANDARD_LWC:

- A `lwc.config.js` file exists at the root
- The `package.json` at the root has one of the following keys in
  `dependencies` or `devDepencencies`
  - starts with `@lwc/`
  - `lwc-services`
- The `package.json` has a root key (configuration) of `lwc`
