### PR TITLE
Save Static Resource Index to file and initialize with it [Proof of concept]

### DIFF
--- a/packages/lwc-language-server/src/metadata-utils/static-resources-util.ts
+++ b/packages/lwc-language-server/src/metadata-utils/static-resources-util.ts
@@ -19,21 +19,25 @@ function getResourceName(resourceMetaFile: string) {
     return parse(resourceFile).name;
 }
 
-export async function updateStaticResourceIndex(updatedFiles: FileEvent[], { workspaceRoots }: WorkspaceContext, writeConfigs: boolean = true) {
+export async function updateStaticResourceIndex(updates: FileEvent[], { workspaceRoots }: WorkspaceContext, writeConfigs: boolean = true) {
     let didChange = false;
-    for (const f of updatedFiles) {
-        if (f.uri.endsWith('.resource-meta.xml')) {
-            if (f.type === FileChangeType.Created) {
-                didChange = true;
-                STATIC_RESOURCES.add(getResourceName(f.uri));
-            } else if (f.type === FileChangeType.Deleted) {
-                STATIC_RESOURCES.delete(getResourceName(f.uri));
-                didChange = true;
+
+    for (const update of updates) {
+        if (update.uri.endsWith('.resource-meta.xml')) {
+            const resourceName = getResourceName(update.uri);
+
+            switch (update.type) {
+                case FileChangeType.Created:
+                    didChange = true;
+                    STATIC_RESOURCES.add(resourceName);
+                case FileChangeType.Deleted:
+                    STATIC_RESOURCES.delete(resourceName);
+                    didChange = true;
             }
         }
-    }
-    if (didChange) {
-        return processStaticResources(workspaceRoots[0], writeConfigs);
+        if (didChange) {
+            return processStaticResources(workspaceRoots[0], writeConfigs);
+        }
     }
 }
 

--- a/packages/lwc-language-server/src/metadata-utils/static-resources-util.ts
+++ b/packages/lwc-language-server/src/metadata-utils/static-resources-util.ts
@@ -64,19 +64,16 @@ export async function indexStaticResources(context: WorkspaceContext, writeConfi
 }
 
 function generateResourceTypeDeclarations(): string {
-    let resTypeDecs = '';
-    const sortedStaticResources = Array.from(STATIC_RESOURCES).sort();
-    sortedStaticResources.forEach(res => {
-        resTypeDecs += generateResourceTypeDeclaration(res);
-    });
-    return resTypeDecs;
+    return Array.from(STATIC_RESOURCES)
+        .sort()
+        .map(resourceDeclaration)
+        .join('');
 }
 
-function generateResourceTypeDeclaration(resourceName: string) {
-    const result = `declare module "@salesforce/resourceUrl/${resourceName}" {
+function resourceDeclaration(resourceName: string) {
+    return `declare module "@salesforce/resourceUrl/${resourceName}" {
     var ${resourceName}: string;
     export default ${resourceName};
 }
 `;
-    return result;
 }

--- a/packages/lwc-language-server/src/metadata-utils/static-resources-util.ts
+++ b/packages/lwc-language-server/src/metadata-utils/static-resources-util.ts
@@ -80,3 +80,12 @@ function resourceDeclaration(resourceName: string) {
 }
 `;
 }
+
+export function persistStaticResources(context: WorkspaceContext) {
+    const { workspaceRoots } = context;
+    const indexPath = join(workspaceRoots[0], STATIC_RESOURCE_INDEX_FILE);
+    const index = Array.from(STATIC_RESOURCES);
+    const indexJsonString = JSON.stringify(index);
+
+    fs.writeFile(indexPath, indexJsonString);
+}

--- a/packages/lwc-language-server/src/metadata-utils/static-resources-util.ts
+++ b/packages/lwc-language-server/src/metadata-utils/static-resources-util.ts
@@ -43,7 +43,10 @@ export async function updateStaticResourceIndex(updates: FileEvent[], { workspac
 
 async function processStaticResources(workspace: string, writeConfigs: boolean): Promise<void> {
     if (STATIC_RESOURCES.size > 0 && writeConfigs) {
-        return fs.writeFile(join(workspace, STATIC_RESOURCE_DECLARATION_FILE), generateResourceTypeDeclarations());
+        const filename = join(workspace, STATIC_RESOURCE_DECLARATION_FILE);
+        const fileContent = generateResourceTypeDeclarations();
+
+        return fs.writeFile(filename, fileContent);
     }
 }
 

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -44,6 +44,9 @@ connection.onCompletionResolve(completionResolve);
 connection.onHover(hover);
 connection.onDefinition(definition);
 connection.onDidChangeWatchedFiles(changedFile);
+connection.onRequest('salesforce/listComponents', () => {
+    return JSON.stringify(getLwcTags());
+});
 
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
@@ -221,8 +224,3 @@ async function changedFile(change: DidChangeWatchedFilesParams) {
         connection.sendNotification(ShowMessageNotification.type, { type: MessageType.Error, message: `Error re-indexing workspace: ${e.message}` });
     }
 }
-
-connection.onRequest('salesforce/listComponents', () => {
-    const tags = getLwcTags();
-    return JSON.stringify([...tags]);
-});

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -52,6 +52,7 @@ connection.onRequest('salesforce/listComponents', () => {
 const documents: TextDocuments = new TextDocuments();
 documents.listen(connection);
 documents.onDidClose(onClose);
+documents.onDidChangeContent(onChangeContent);
 
 async function initialize(params: InitializeParams): Promise<InitializeResult> {
     try {
@@ -113,7 +114,7 @@ function onClose(event) {
     connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
 }
 
-documents.onDidChangeContent(async change => {
+async function onChangeContent(change) {
     // TODO: when hovering on an html tag, this is called for the target .js document (bug in vscode?)
     const { document } = change;
     const { uri } = document;
@@ -128,7 +129,7 @@ documents.onDidChangeContent(async change => {
             addCustomTagFromResults(context, uri, metadata, context.type === WorkspaceType.SFDX, false);
         }
     }
-});
+}
 
 documents.onDidSave(async change => {
     const { document } = change;

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -51,6 +51,7 @@ connection.onRequest('salesforce/listComponents', () => {
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
 documents.listen(connection);
+documents.onDidClose(onClose);
 
 async function initialize(params: InitializeParams): Promise<InitializeResult> {
     try {
@@ -108,10 +109,9 @@ function workspaceRoots(folders: WorkspaceFolder[]): string[] {
     });
 }
 
-// Make sure to clear all the diagnostics when a document gets closed
-documents.onDidClose(event => {
+function onClose(event) {
     connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
-});
+}
 
 documents.onDidChangeContent(async change => {
     // TODO: when hovering on an html tag, this is called for the target .js document (bug in vscode?)

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -40,6 +40,7 @@ const connection: IConnection = createConnection();
 interceptConsoleLogger(connection);
 connection.onInitialize(initialize);
 connection.onCompletion(completion);
+connection.onCompletionResolve(completionResolve);
 
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
@@ -146,11 +147,9 @@ async function completion(textDocumentPosition: TextDocumentPositionParams): Pro
     });
 }
 
-connection.onCompletionResolve(
-    (item: CompletionItem): CompletionItem => {
-        return item;
-    },
-);
+function completionResolve(item: CompletionItem): CompletionItem {
+    return item;
+}
 
 connection.onHover(
     async (textDocumentPosition: TextDocumentPositionParams): Promise<Hover> => {

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -10,6 +10,7 @@ import {
     CompletionList,
     CompletionItem,
     DidChangeWatchedFilesParams,
+    TextDocumentChangeEvent,
     Hover,
     Location,
     ShowMessageNotification,
@@ -114,11 +115,11 @@ function workspaceRoots(folders: WorkspaceFolder[]): string[] {
     });
 }
 
-function onClose(event) {
+function onClose(event: TextDocumentChangeEvent) {
     connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
 }
 
-async function onChangeContent(change) {
+async function onChangeContent(change: TextDocumentChangeEvent) {
     // TODO: when hovering on an html tag, this is called for the target .js document (bug in vscode?)
     const { document } = change;
     const { uri } = document;
@@ -135,7 +136,7 @@ async function onChangeContent(change) {
     }
 }
 
-async function onSave(change) {
+async function onSave(change: TextDocumentChangeEvent) {
     const { document } = change;
     const isLWCDocument = await context.isLWCJavascript(document);
 

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -53,6 +53,7 @@ const documents: TextDocuments = new TextDocuments();
 documents.listen(connection);
 documents.onDidClose(onClose);
 documents.onDidChangeContent(onChangeContent);
+documents.onDidSave(onSave);
 
 async function initialize(params: InitializeParams): Promise<InitializeResult> {
     try {
@@ -131,16 +132,17 @@ async function onChangeContent(change) {
     }
 }
 
-documents.onDidSave(async change => {
+async function onSave(change) {
     const { document } = change;
-    const { uri } = document;
-    if (await context.isLWCJavascript(document)) {
+    const isLWCDocument = await context.isLWCJavascript(document);
+
+    if (isLWCDocument) {
         const { metadata } = await javascriptCompileDocument(document);
         if (metadata) {
-            addCustomTagFromResults(context, uri, metadata, context.type === WorkspaceType.SFDX);
+            addCustomTagFromResults(context, document.uri, metadata, context.type === WorkspaceType.SFDX);
         }
     }
-});
+}
 
 async function completion(textDocumentPosition: TextDocumentPositionParams): Promise<CompletionList> {
     const document = documents.get(textDocumentPosition.textDocument.uri);

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -38,6 +38,9 @@ const { WorkspaceType } = shared;
 
 const connection: IConnection = createConnection();
 interceptConsoleLogger(connection);
+
+// Listen on the connection
+connection.listen();
 connection.onInitialize(initialize);
 connection.onCompletion(completion);
 connection.onCompletionResolve(completionResolve);
@@ -216,9 +219,6 @@ async function definition(textDocumentPosition: TextDocumentPositionParams): Pro
     }
     return def;
 }
-
-// Listen on the connection
-connection.listen();
 
 async function changedFile(change: DidChangeWatchedFilesParams) {
     try {

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -48,6 +48,7 @@ connection.onCompletionResolve(completionResolve);
 connection.onHover(hover);
 connection.onDefinition(definition);
 connection.onDidChangeWatchedFiles(changedFile);
+connection.onShutdown(shutdown);
 connection.onRequest('salesforce/listComponents', () => {
     return JSON.stringify(getLwcTags());
 });
@@ -227,4 +228,8 @@ async function changedFile(change: DidChangeWatchedFilesParams) {
     } catch (e) {
         connection.sendNotification(ShowMessageNotification.type, { type: MessageType.Error, message: `Error re-indexing workspace: ${e.message}` });
     }
+}
+
+async function shutdown() {
+    return indexer.persistIndex();
 }

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -41,6 +41,7 @@ interceptConsoleLogger(connection);
 connection.onInitialize(initialize);
 connection.onCompletion(completion);
 connection.onCompletionResolve(completionResolve);
+connection.onHover(hover);
 
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
@@ -151,16 +152,14 @@ function completionResolve(item: CompletionItem): CompletionItem {
     return item;
 }
 
-connection.onHover(
-    async (textDocumentPosition: TextDocumentPositionParams): Promise<Hover> => {
-        const document = documents.get(textDocumentPosition.textDocument.uri);
-        if (!(await context.isLWCTemplate(document))) {
-            return null;
-        }
-        const htmlDocument = htmlLS.parseHTMLDocument(document);
-        return htmlLS.doHover(document, textDocumentPosition.position, htmlDocument);
-    },
-);
+async function hover(textDocumentPosition: TextDocumentPositionParams): Promise<Hover> {
+    const document = documents.get(textDocumentPosition.textDocument.uri);
+    if (!(await context.isLWCTemplate(document))) {
+        return null;
+    }
+    const htmlDocument = htmlLS.parseHTMLDocument(document);
+    return htmlLS.doHover(document, textDocumentPosition.position, htmlDocument);
+}
 
 function findJavascriptProperty(valueProperty: string, textDocumentPosition: TextDocumentPositionParams) {
     // couldn't find it within the markup file, try looking for it as a javascript property

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -43,6 +43,7 @@ connection.onCompletion(completion);
 connection.onCompletionResolve(completionResolve);
 connection.onHover(hover);
 connection.onDefinition(definition);
+connection.onDidChangeWatchedFiles(changedFile);
 
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
@@ -213,13 +214,13 @@ async function definition(textDocumentPosition: TextDocumentPositionParams): Pro
 // Listen on the connection
 connection.listen();
 
-connection.onDidChangeWatchedFiles(async (change: DidChangeWatchedFilesParams) => {
+async function changedFile(change: DidChangeWatchedFilesParams) {
     try {
         return indexer.handleWatchedFiles(context, change);
     } catch (e) {
         connection.sendNotification(ShowMessageNotification.type, { type: MessageType.Error, message: `Error re-indexing workspace: ${e.message}` });
     }
-});
+}
 
 connection.onRequest('salesforce/listComponents', () => {
     const tags = getLwcTags();


### PR DESCRIPTION
Pre-requisite: Merge https://github.com/forcedotcom/lightning-language-server/pull/123 as it this builds on top of it.

### What does this PR do?
In an effort to prevent the indexer from duplicating effort across Aura and LWC language servers:
- When the language server shuts down, save its `STATIC_RESOURCES` index as a JSON file located in `./.sfdx/indexes/lwc/staticresources.json`
- When the language server indexes static components for the first time, load from a said file instead of regenerating the entire index.
- This should only occur if the in-memory static resources index is empty.


### What issues does this PR fix or reference?
