### PR TITLE
Persist all indexes on LWC servers shutdown event

### DIFF
--- a/packages/lwc-language-server/src/indexer.ts
+++ b/packages/lwc-language-server/src/indexer.ts
@@ -34,18 +34,24 @@ export class LWCIndexer implements Indexer {
     }
 
     public async configureAndIndex() {
-        const indexingTasks: Promise<void>[] = [];
+        const tasks: Promise<void>[] = [indexCustomComponents(this.context, this.writeConfigs)];
+
         if (this.context.type !== WorkspaceType.STANDARD_LWC) {
-            indexingTasks.push(loadStandardComponents(this.context, this.writeConfigs));
+            tasks.push(loadStandardComponents(this.context, this.writeConfigs));
         }
-        indexingTasks.push(indexCustomComponents(this.context, this.writeConfigs));
+
         if (this.context.type === WorkspaceType.SFDX) {
-            indexingTasks.push(indexStaticResources(this.context, this.writeConfigs));
-            indexingTasks.push(indexContentAssets(this.context, this.writeConfigs));
-            indexingTasks.push(indexCustomLabels(this.context, this.writeConfigs));
-            indexingTasks.push(indexMessageChannels(this.context, this.writeConfigs));
+            tasks.push(
+                ...[
+                    indexStaticResources(this.context, this.writeConfigs),
+                    indexContentAssets(this.context, this.writeConfigs),
+                    indexCustomLabels(this.context, this.writeConfigs),
+                    indexMessageChannels(this.context, this.writeConfigs),
+                ],
+            );
         }
-        this.indexingTasks = Promise.all(indexingTasks).then(() => undefined);
+
+        this.indexingTasks = await Promise.all(tasks).then(() => undefined);
         return this.indexingTasks;
     }
 

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -44,6 +44,9 @@ connection.onCompletionResolve(completionResolve);
 connection.onHover(hover);
 connection.onDefinition(definition);
 connection.onDidChangeWatchedFiles(changedFile);
+connection.onRequest('salesforce/listComponents', () => {
+    return JSON.stringify(getLwcTags());
+});
 
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
@@ -221,8 +224,3 @@ async function changedFile(change: DidChangeWatchedFilesParams) {
         connection.sendNotification(ShowMessageNotification.type, { type: MessageType.Error, message: `Error re-indexing workspace: ${e.message}` });
     }
 }
-
-connection.onRequest('salesforce/listComponents', () => {
-    const tags = getLwcTags();
-    return JSON.stringify([...tags]);
-});

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -52,6 +52,7 @@ connection.onRequest('salesforce/listComponents', () => {
 const documents: TextDocuments = new TextDocuments();
 documents.listen(connection);
 documents.onDidClose(onClose);
+documents.onDidChangeContent(onChangeContent);
 
 async function initialize(params: InitializeParams): Promise<InitializeResult> {
     try {
@@ -113,7 +114,7 @@ function onClose(event) {
     connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
 }
 
-documents.onDidChangeContent(async change => {
+async function onChangeContent(change) {
     // TODO: when hovering on an html tag, this is called for the target .js document (bug in vscode?)
     const { document } = change;
     const { uri } = document;
@@ -128,7 +129,7 @@ documents.onDidChangeContent(async change => {
             addCustomTagFromResults(context, uri, metadata, context.type === WorkspaceType.SFDX, false);
         }
     }
-});
+}
 
 documents.onDidSave(async change => {
     const { document } = change;

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -51,6 +51,7 @@ connection.onRequest('salesforce/listComponents', () => {
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
 documents.listen(connection);
+documents.onDidClose(onClose);
 
 async function initialize(params: InitializeParams): Promise<InitializeResult> {
     try {
@@ -108,10 +109,9 @@ function workspaceRoots(folders: WorkspaceFolder[]): string[] {
     });
 }
 
-// Make sure to clear all the diagnostics when a document gets closed
-documents.onDidClose(event => {
+function onClose(event) {
     connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
-});
+}
 
 documents.onDidChangeContent(async change => {
     // TODO: when hovering on an html tag, this is called for the target .js document (bug in vscode?)

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -40,6 +40,7 @@ const connection: IConnection = createConnection();
 interceptConsoleLogger(connection);
 connection.onInitialize(initialize);
 connection.onCompletion(completion);
+connection.onCompletionResolve(completionResolve);
 
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
@@ -146,11 +147,9 @@ async function completion(textDocumentPosition: TextDocumentPositionParams): Pro
     });
 }
 
-connection.onCompletionResolve(
-    (item: CompletionItem): CompletionItem => {
-        return item;
-    },
-);
+function completionResolve(item: CompletionItem): CompletionItem {
+    return item;
+}
 
 connection.onHover(
     async (textDocumentPosition: TextDocumentPositionParams): Promise<Hover> => {

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -10,6 +10,7 @@ import {
     CompletionList,
     CompletionItem,
     DidChangeWatchedFilesParams,
+    TextDocumentChangeEvent,
     Hover,
     Location,
     ShowMessageNotification,
@@ -114,11 +115,11 @@ function workspaceRoots(folders: WorkspaceFolder[]): string[] {
     });
 }
 
-function onClose(event) {
+function onClose(event: TextDocumentChangeEvent) {
     connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
 }
 
-async function onChangeContent(change) {
+async function onChangeContent(change: TextDocumentChangeEvent) {
     // TODO: when hovering on an html tag, this is called for the target .js document (bug in vscode?)
     const { document } = change;
     const { uri } = document;
@@ -135,7 +136,7 @@ async function onChangeContent(change) {
     }
 }
 
-async function onSave(change) {
+async function onSave(change: TextDocumentChangeEvent) {
     const { document } = change;
     const isLWCDocument = await context.isLWCJavascript(document);
 

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -53,6 +53,7 @@ const documents: TextDocuments = new TextDocuments();
 documents.listen(connection);
 documents.onDidClose(onClose);
 documents.onDidChangeContent(onChangeContent);
+documents.onDidSave(onSave);
 
 async function initialize(params: InitializeParams): Promise<InitializeResult> {
     try {
@@ -131,16 +132,17 @@ async function onChangeContent(change) {
     }
 }
 
-documents.onDidSave(async change => {
+async function onSave(change) {
     const { document } = change;
-    const { uri } = document;
-    if (await context.isLWCJavascript(document)) {
+    const isLWCDocument = await context.isLWCJavascript(document);
+
+    if (isLWCDocument) {
         const { metadata } = await javascriptCompileDocument(document);
         if (metadata) {
-            addCustomTagFromResults(context, uri, metadata, context.type === WorkspaceType.SFDX);
+            addCustomTagFromResults(context, document.uri, metadata, context.type === WorkspaceType.SFDX);
         }
     }
-});
+}
 
 async function completion(textDocumentPosition: TextDocumentPositionParams): Promise<CompletionList> {
     const document = documents.get(textDocumentPosition.textDocument.uri);

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -38,6 +38,9 @@ const { WorkspaceType } = shared;
 
 const connection: IConnection = createConnection();
 interceptConsoleLogger(connection);
+
+// Listen on the connection
+connection.listen();
 connection.onInitialize(initialize);
 connection.onCompletion(completion);
 connection.onCompletionResolve(completionResolve);
@@ -216,9 +219,6 @@ async function definition(textDocumentPosition: TextDocumentPositionParams): Pro
     }
     return def;
 }
-
-// Listen on the connection
-connection.listen();
 
 async function changedFile(change: DidChangeWatchedFilesParams) {
     try {

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -48,6 +48,7 @@ connection.onCompletionResolve(completionResolve);
 connection.onHover(hover);
 connection.onDefinition(definition);
 connection.onDidChangeWatchedFiles(changedFile);
+connection.onShutdown(shutdown);
 connection.onRequest('salesforce/listComponents', () => {
     return JSON.stringify(getLwcTags());
 });
@@ -227,4 +228,8 @@ async function changedFile(change: DidChangeWatchedFilesParams) {
     } catch (e) {
         connection.sendNotification(ShowMessageNotification.type, { type: MessageType.Error, message: `Error re-indexing workspace: ${e.message}` });
     }
+}
+
+async function shutdown() {
+    return indexer.persistIndex();
 }

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -41,6 +41,7 @@ interceptConsoleLogger(connection);
 connection.onInitialize(initialize);
 connection.onCompletion(completion);
 connection.onCompletionResolve(completionResolve);
+connection.onHover(hover);
 
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
@@ -151,16 +152,14 @@ function completionResolve(item: CompletionItem): CompletionItem {
     return item;
 }
 
-connection.onHover(
-    async (textDocumentPosition: TextDocumentPositionParams): Promise<Hover> => {
-        const document = documents.get(textDocumentPosition.textDocument.uri);
-        if (!(await context.isLWCTemplate(document))) {
-            return null;
-        }
-        const htmlDocument = htmlLS.parseHTMLDocument(document);
-        return htmlLS.doHover(document, textDocumentPosition.position, htmlDocument);
-    },
-);
+async function hover(textDocumentPosition: TextDocumentPositionParams): Promise<Hover> {
+    const document = documents.get(textDocumentPosition.textDocument.uri);
+    if (!(await context.isLWCTemplate(document))) {
+        return null;
+    }
+    const htmlDocument = htmlLS.parseHTMLDocument(document);
+    return htmlLS.doHover(document, textDocumentPosition.position, htmlDocument);
+}
 
 function findJavascriptProperty(valueProperty: string, textDocumentPosition: TextDocumentPositionParams) {
     // couldn't find it within the markup file, try looking for it as a javascript property

--- a/packages/lwc-language-server/src/server.ts
+++ b/packages/lwc-language-server/src/server.ts
@@ -43,6 +43,7 @@ connection.onCompletion(completion);
 connection.onCompletionResolve(completionResolve);
 connection.onHover(hover);
 connection.onDefinition(definition);
+connection.onDidChangeWatchedFiles(changedFile);
 
 // Create a document namager supporting only full document sync
 const documents: TextDocuments = new TextDocuments();
@@ -213,13 +214,13 @@ async function definition(textDocumentPosition: TextDocumentPositionParams): Pro
 // Listen on the connection
 connection.listen();
 
-connection.onDidChangeWatchedFiles(async (change: DidChangeWatchedFilesParams) => {
+async function changedFile(change: DidChangeWatchedFilesParams) {
     try {
         return indexer.handleWatchedFiles(context, change);
     } catch (e) {
         connection.sendNotification(ShowMessageNotification.type, { type: MessageType.Error, message: `Error re-indexing workspace: ${e.message}` });
     }
-});
+}
 
 connection.onRequest('salesforce/listComponents', () => {
     const tags = getLwcTags();


### PR DESCRIPTION
### What issues does this PR fix or reference?
Persist all indexes to `/.sfdx/indexes/lwc/*` to be loaded when the server initializes.