### PR TITLE
Rename use of 'lwc.config.js` to `lwc.config.json`

### DIFF
--- a/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/workspace-type.test.ts
@@ -30,10 +30,10 @@ describe('detectWorkspaceType', () => {
         expect(workspaceType).toEqual(WorkspaceType.SFDX);
     });
 
-    test('when an lwc.config.js file is present, workspaceType is STANDARD_LWC', () => {
+    test('when an lwc.config.json file is present, workspaceType is STANDARD_LWC', () => {
         mockFs({
             workspacedir: {
-                'lwc.config.js': '',
+                'lwc.config.json': '',
             },
         });
 

--- a/packages/lightning-lsp-common/src/shared.ts
+++ b/packages/lightning-lsp-common/src/shared.ts
@@ -73,7 +73,7 @@ export function detectWorkspaceHelper(root: string): WorkspaceType {
         return WorkspaceType.CORE_PARTIAL;
     }
 
-    if (fs.existsSync(path.join(root, 'lwc.config.js'))) {
+    if (fs.existsSync(path.join(root, 'lwc.config.json'))) {
         return WorkspaceType.STANDARD_LWC;
     }
 


### PR DESCRIPTION
### What does this PR do?
According to the [LWC Docs](https://rfcs.lwc.dev/rfcs/lwc/0020-module-resolution#lwc-configuration) we should using the `lwc.config.json` file to determine if the workspace is "STANDARD_LWC" not a `lwc.config.js` file.



### What issues does this PR fix or reference?