### PR TITLE
feat(common): add typings for getObjectInfos

### DIFF
--- a/packages/lightning-lsp-common/src/resources/sfdx/typings/lds.d.ts
+++ b/packages/lightning-lsp-common/src/resources/sfdx/typings/lds.d.ts
@@ -77,6 +77,13 @@ declare module 'lightning/uiObjectInfoApi' {
     export function getObjectInfo(objectApiName: string | ObjectId): void;
 
     /**
+     * Wire adapter for multiple object metadatas.
+     *
+     * @param objectApiNames The API names of the objects to retrieve.
+     */
+    export function getObjectInfos(objectApiNames: Array<string | ObjectId>): void;
+
+    /**
      * Wire adapter for values for a picklist field.
      *
      * https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_picklist_values.htm


### PR DESCRIPTION
### What does this PR do?
It adds typing for a new adapter `getObjectInfos` exposed through `lightning/uiObjectInfoApi` module.

### What issues does this PR fix or reference?
[W-7454278](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007QdZWIA0/view)