### PR TITLE
Fix "Request textDocument/codeAction failed" in SLDS extension

### DIFF
--- a/packages/lwc-language-server/src/constants.ts
+++ b/packages/lwc-language-server/src/constants.ts
@@ -1,1 +1,2 @@
 export const DIAGNOSTIC_SOURCE = 'lwc';
+export const MAX_32BIT_INTEGER = 2 ** 31 - 1;

--- a/packages/lwc-language-server/src/javascript/__tests__/compiler.test.ts
+++ b/packages/lwc-language-server/src/javascript/__tests__/compiler.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { TextDocument } from 'vscode-languageserver';
-import { DIAGNOSTIC_SOURCE } from '../../constants';
+import { DIAGNOSTIC_SOURCE, MAX_32BIT_INTEGER } from '../../constants';
 import { compile } from '@lwc/compiler';
 import { transform } from '@lwc/compiler';
 import { Metadata } from '@lwc/babel-plugin-component';
@@ -172,7 +172,7 @@ it('compileDocument returns list of javascript syntax errors', async () => {
     expect(diagnostics[0].message).toMatch('Unexpected token (4:17)');
     expect(diagnostics[0].range).toMatchObject({
         start: { character: 17 },
-        end: { character: Number.MAX_VALUE },
+        end: { character: MAX_32BIT_INTEGER },
     });
     expect(diagnostics[0].source).toBe(DIAGNOSTIC_SOURCE);
 });
@@ -185,7 +185,7 @@ it('compileDocument returns list of javascript regular errors', async () => {
     expect(diagnostics[0].message).toMatch('Boolean public property must default to false.');
     expect(diagnostics[0].range).toMatchObject({
         start: { character: 4 },
-        end: { character: Number.MAX_VALUE },
+        end: { character: MAX_32BIT_INTEGER },
     });
     expect(diagnostics[0].source).toBe(DIAGNOSTIC_SOURCE);
 });

--- a/packages/lwc-language-server/src/javascript/compiler.ts
+++ b/packages/lwc-language-server/src/javascript/compiler.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { Diagnostic, DiagnosticSeverity, Location, Position, Range, TextDocument } from 'vscode-languageserver';
 import URI from 'vscode-uri';
-import { DIAGNOSTIC_SOURCE } from '../constants';
+import { DIAGNOSTIC_SOURCE, MAX_32BIT_INTEGER } from '../constants';
 import { transform } from '@lwc/compiler';
 import { CompilerOptions } from '@lwc/compiler/dist/types/compiler/options';
 import { ClassMember } from '@lwc/babel-plugin-component';
@@ -136,7 +136,9 @@ function toDiagnostic(err: any): Diagnostic {
     }
     const startLine: number = location.line - 1;
     const startCharacter: number = location.column;
-    const range = Range.create(startLine, startCharacter, startLine, Number.MAX_VALUE);
+    // https://github.com/forcedotcom/salesforcedx-vscode/issues/2074
+    // Limit the end character to max 32 bit integer so that it doesn't overflow other language servers
+    const range = Range.create(startLine, startCharacter, startLine, MAX_32BIT_INTEGER);
     return {
         range,
         severity: DiagnosticSeverity.Error,


### PR DESCRIPTION
### What does this PR do?
Fixes error message in SLDS extensions output when working with an LWC file that contains compile errors.
The cause of the issue is that LWC language server generates a diagnostics message with an overflowing value, which get passed on by VS Code and SLDS extension could not handle it.

There's a similar [issue](https://github.com/microsoft/vscode/issues/80288) from VS Code where the diagnostics are generated from problem matchers.

Thanks @billyma for the help in locating the root cause.

### What issues does this PR fix or reference?
Fixes https://github.com/forcedotcom/salesforcedx-vscode/issues/2074, https://github.com/forcedotcom/salesforcedx-vscode-slds/issues/25, @W-7387177@