### PR TITLE
Missed package @salesforce/apex

### DIFF
--- a/packages/lightning-lsp-common/package.json
+++ b/packages/lightning-lsp-common/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@lwc/babel-plugin-component": "0.34.8",
-    "@salesforce/apex": "0.0.12",
     "decamelize": "^2.0.0",
     "deep-equal": "^1.0.1",
     "fs-extra": "^5.0.0",
@@ -43,6 +42,7 @@
   },
   "devDependencies": {
     "@lwc/engine": "0.34.8",
+    "@salesforce/apex": "0.0.12",
     "@types/decamelize": "^1.2.0",
     "@types/deep-equal": "^1.0.1",
     "@types/fs-extra": "^5.0.4",

--- a/packages/lightning-lsp-common/package.json
+++ b/packages/lightning-lsp-common/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@lwc/babel-plugin-component": "0.34.8",
+    "@salesforce/apex": "0.0.12",
     "decamelize": "^2.0.0",
     "deep-equal": "^1.0.1",
     "fs-extra": "^5.0.0",


### PR DESCRIPTION
This PR adds the dependency @salesforce/apex into the lightning-lsp-common package. 
It's copied on scripts/copy_typings.js, and used on test lightning-lsp-common/src/_tests_/context.test.ts:201 (Where it checks for apex.d.ts file)
