### PR TITLE
fix: fix lwc server init in core modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
   "npm.packageManager": "yarn",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-  "eslint.format.enable": true
+  "eslint.format.enable": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  }
 }

--- a/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
+++ b/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
@@ -302,3 +302,39 @@ describe('findDynamicContent', () => {
         expect(findDynamicContent(text, 25)).toBeNull();
     });
 });
+
+describe('Core All Workspace', () => {
+    const initializeParams: InitializeParams = {
+        processId: 0,
+        rootUri: '',
+        capabilities: {},
+        workspaceFolders: [
+            {
+                uri: URI.file(path.resolve('../../test-workspaces/core-like-workspace/app/main/core')).toString(),
+                name: path.resolve('../../test-workspaces/sfdx-workspace/'),
+            },
+        ],
+    };
+
+    it('Should not throw during intialization', async () => {
+        await server.onInitialize(initializeParams);
+    });
+});
+
+describe('Core Partial Workspace', () => {
+    const initializeParams: InitializeParams = {
+        processId: 0,
+        rootUri: '',
+        capabilities: {},
+        workspaceFolders: [
+            {
+                uri: URI.file(path.resolve('../../test-workspaces/core-like-workspace/app/main/core/ui-global-components')).toString(),
+                name: path.resolve('../../test-workspaces/sfdx-workspace/'),
+            },
+        ],
+    };
+
+    it('Should not throw during intialization', async () => {
+        await server.onInitialize(initializeParams);
+    });
+});


### PR DESCRIPTION
### What does this PR do?
Fix lwc server init in core modules: CORE_ALL and CORE_PARTIAL workspace.
The root cause of this issue is `typing-indexer` looks up `sfdxPackageDirsPattern` which is read from `sfdx-project.json`, but core workspaces don't have `sfdx-project.json` files.

### What issues does this PR fix or reference?
@W-8108703@
