### PR TITLE
Trigger completions on specific characters

### DIFF
--- a/packages/aura-language-server/src/server.ts
+++ b/packages/aura-language-server/src/server.ts
@@ -107,6 +107,7 @@ connection.onInitialize(
                     textDocumentSync: documents.syncKind,
                     completionProvider: {
                         resolveProvider: true,
+                        triggerCharacters: [':', '<', '"', '=', '/', '>'],
                     },
                     workspace: {
                         workspaceFolders: {

--- a/packages/aura-language-server/src/server.ts
+++ b/packages/aura-language-server/src/server.ts
@@ -107,7 +107,7 @@ connection.onInitialize(
                     textDocumentSync: documents.syncKind,
                     completionProvider: {
                         resolveProvider: true,
-                        triggerCharacters: [':', '<', '"', '=', '/', '>'],
+                        triggerCharacters: ['{', '.', ':', '<', '"', '=', '/', '>'],
                     },
                     workspace: {
                         workspaceFolders: {

--- a/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
+++ b/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
@@ -220,7 +220,7 @@ describe('#capabilities', () => {
                 textDocumentSync: 'html',
                 completionProvider: {
                     resolveProvider: true,
-                    triggerCharacters: ['-', '_', '<', '"', '=', '/', '>'],
+                    triggerCharacters: ['{', '.', '-', '_', '<', '"', '=', '/', '>'],
                 },
                 hoverProvider: true,
                 definitionProvider: true,

--- a/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
+++ b/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
@@ -220,6 +220,7 @@ describe('#capabilities', () => {
                 textDocumentSync: 'html',
                 completionProvider: {
                     resolveProvider: true,
+                    triggerCharacters: ['-', '_', '<', '"', '=', '/', '>'],
                 },
                 hoverProvider: true,
                 definitionProvider: true,

--- a/packages/lwc-language-server/src/lwc-server.ts
+++ b/packages/lwc-language-server/src/lwc-server.ts
@@ -116,7 +116,7 @@ export default class Server {
                 textDocumentSync: this.documents.syncKind,
                 completionProvider: {
                     resolveProvider: true,
-                    triggerCharacters: ['-', '_', '<', '"', '=', '/', '>'],
+                    triggerCharacters: ['{', '.', '-', '_', '<', '"', '=', '/', '>'],
                 },
                 hoverProvider: true,
                 definitionProvider: true,

--- a/packages/lwc-language-server/src/lwc-server.ts
+++ b/packages/lwc-language-server/src/lwc-server.ts
@@ -116,6 +116,7 @@ export default class Server {
                 textDocumentSync: this.documents.syncKind,
                 completionProvider: {
                     resolveProvider: true,
+                    triggerCharacters: ['-', '_', '<', '"', '=', '/', '>'],
                 },
                 hoverProvider: true,
                 definitionProvider: true,


### PR DESCRIPTION
### What does this PR do?
Update completion provider configs to trigger the event when a user types aura/lwc tag characters.

### What issues does this PR fix or reference?
@W-8017548@, @W-8017525@

#### Aura Before
![aura-completions-before](https://user-images.githubusercontent.com/1041842/94639632-7fa58700-0291-11eb-84a4-95791cd73591.gif)

#### Aura After
![aura-completions-after](https://user-images.githubusercontent.com/1041842/94639650-87652b80-0291-11eb-9c63-164596ef52a1.gif)

#### LWC Before
![lwc-completions-before](https://user-images.githubusercontent.com/1041842/94639733-c0050500-0291-11eb-80b3-832cb847ea5f.gif)

#### LWC After
![lwc-completions-after](https://user-images.githubusercontent.com/1041842/94639782-d90db600-0291-11eb-84a7-ce78f6a0cba5.gif)




