### PR TITLE
fix: handle empty custom labels when creating types

### DIFF
--- a/packages/lwc-language-server/src/__tests__/typing-indexer.test.ts
+++ b/packages/lwc-language-server/src/__tests__/typing-indexer.test.ts
@@ -50,6 +50,7 @@ describe('TypingIndexer', () => {
     describe('#saveCustomLabelTypings', () => {
         afterEach(() => {
             fsExtra.removeSync(typingIndexer.typingsBaseDir);
+            jest.restoreAllMocks();
         });
 
         it('saves the custom labels xml file to 1 typings file', async () => {
@@ -57,6 +58,17 @@ describe('TypingIndexer', () => {
             const customLabelPath: string = path.join(typingIndexer.workspaceRoot, '.sfdx', 'typings', 'lwc', 'customlabels.d.ts');
             expect(fsExtra.pathExistsSync(customLabelPath)).toBeTrue();
             expect(fsExtra.readFileSync(customLabelPath).toString()).toInclude('declare module');
+        });
+
+        it('should not create a customlabels typing file when a project has no custom labels', async () => {
+            const xmlDocument = `
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata"/>
+`;
+            jest.spyOn(fsExtra, 'readFileSync').mockReturnValue(Buffer.from(xmlDocument));
+            const fileWriter = jest.spyOn(fsExtra, 'writeFileSync');
+            await typingIndexer.saveCustomLabelTypings();
+            expect(fileWriter).toBeCalledTimes(0);
         });
     });
 

--- a/packages/lwc-language-server/src/__tests__/typing.test.ts
+++ b/packages/lwc-language-server/src/__tests__/typing.test.ts
@@ -97,4 +97,14 @@ describe('Typing.fromCustomLabels', () => {
 
         expect(typings).toEqual(expectedDeclarations);
     });
+
+    it('should not generate declarations when parsing an empty labels xml document', async () => {
+        const xmlDocument = `
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata"/>
+`;
+
+        const typings: string = await Typing.declarationsFromCustomLabels(xmlDocument);
+        expect(typings).toEqual('');
+    });
 });

--- a/packages/lwc-language-server/src/typing-indexer.ts
+++ b/packages/lwc-language-server/src/typing-indexer.ts
@@ -77,8 +77,9 @@ export default class TypingIndexer extends BaseIndexer {
         });
         const typingContent = await Promise.all(typings);
         const fileContent = typingContent.join('\n');
-
-        fsExtra.writeFileSync(this.customLabelTypings, fileContent);
+        if (fileContent.length !== 0) {
+            fsExtra.writeFileSync(this.customLabelTypings, fileContent);
+        }
     }
 
     get metaFiles(): string[] {

--- a/packages/lwc-language-server/src/typing.ts
+++ b/packages/lwc-language-server/src/typing.ts
@@ -55,6 +55,9 @@ export default class Typing {
 
     static async declarationsFromCustomLabels(xmlDocument: string | Buffer): Promise<string> {
         const doc = await new xml2js.Parser().parseStringPromise(xmlDocument);
+        if (doc.CustomLabels === undefined || doc.CustomLabels.labels === undefined) {
+            return '';
+        }
         const declarations = doc.CustomLabels.labels.map((label: { [key: string]: string[] }) => {
             return declaration('customLabel', label.fullName[0]);
         });


### PR DESCRIPTION
### What does this PR do?
Fixes the issue of the language server throwing an error when parsing an empty custom labels file. 

### What issues does this PR fix or reference?
https://github.com/forcedotcom/salesforcedx-vscode/issues/2575, @W-81658202