### PR TITLE
feat(common): add typings for getObjectInfos

### DIFF
--- a/packages/lightning-lsp-common/src/resources/sfdx/typings/lds.d.ts
+++ b/packages/lightning-lsp-common/src/resources/sfdx/typings/lds.d.ts
@@ -78,6 +78,13 @@ declare module 'lightning/uiObjectInfoApi' {
     export function getObjectInfo(objectApiName: string | ObjectId): void;
 
     /**
+     * Wire adapter for multiple object metadatas.
+     *
+     * @param objectApiNames The API names of the objects to retrieve.
+     */
+    export function getObjectInfos(objectApiNames: Array<string | ObjectId>): void;
+
+    /**
      * Wire adapter for values for a picklist field.
      *
      * https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_wire_adapters_picklist_values


### PR DESCRIPTION
### What does this PR do?

It adds typing for a new adapter getObjectInfos exposed through lightning/uiObjectInfoApi module. Porting #172 to develop.

### What issues does this PR fix or reference?

@W-7454278@