### PR TITLE
chore: add context restriction for publish workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ workflows:
       - build-and-test-linux
       - build-and-test-win
       - publish:
+          context: pdt-publish-restricted-context
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,14 @@ workflows:
   publish-workflow:
     when: << pipeline.parameters.publish >>
     jobs:
+      - slack/approval-notification:
+          message: Pending Approval for Publish of Lightning Language Server
+          channel: 'pdt_releases'
+          color: '#0E1111'
       - build-and-test-linux
       - build-and-test-win
+      - hold: # Requires manual approval in Circle Ci
+          type: approval
       - publish:
           context: pdt-publish-restricted-context
           filters:
@@ -150,3 +156,4 @@ workflows:
           requires:
             - build-and-test-linux
             - build-and-test-win
+            - hold


### PR DESCRIPTION
### What does this PR do?
Restricts approval access for circle ci workflows. Only members of the GitHub Team 'PDT' should be able to approve workflows for publishing.

### What issues does this PR fix or reference?
@W-8165486@