### PR TITLE
Add typings for getMetrics Scale Center LDS adapter

### DIFF
--- a/packages/lightning-lsp-common/src/resources/sfdx/typings/lds.d.ts
+++ b/packages/lightning-lsp-common/src/resources/sfdx/typings/lds.d.ts
@@ -548,6 +548,16 @@ declare module 'lightning/uiRecordApi' {
     export function getFieldDisplayValue(record: RecordRepresentation, field: FieldId | string): FieldValueRepresentationValue | undefined;
 }
 
+declare module 'lightning/platformScaleCenterApi' {
+    /**
+     * Wire adapter for a Scale Center observability metrics.     
+     * 
+     * @param request a serialized list of ScaleCenterRequests that define which metrics are to be queried
+     * @returns a serialized list of the requested metric data
+     */
+     export function getMetrics( request: string ): void;
+}
+
 declare module 'lightning/analyticsWaveApi' {
     /**
      * A Wave dataflow node.


### PR DESCRIPTION
### What does this PR do?

It adds typing for a new adapter getMetrics exposed through lightning/platformScaleCenterApi module.

### What issues does this PR fix or reference?
W-9283986
