### PR TITLE
chore: updated lwc debug port

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
       "name": "Debug LWC LSP",
       "type": "node",
       "request": "attach",
-      "port": 6009,
+      "port": 6030,
       "sourceMaps": true,
       "outFiles": ["${workspaceFolder}/packages/lwc-language-server/lib/**"],
       "protocol": "inspector",

--- a/packages/lwc-language-server/.vscode/launch.json
+++ b/packages/lwc-language-server/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Debug LWC LSP",
             "type": "node",
             "request": "attach",
-            "port": 6009,
+            "port": 6030,
             "sourceMaps": true,
             "outFiles": [
                 "${workspaceFolder}/lib/**"


### PR DESCRIPTION
### What does this PR do?
In conjunction with the vscode update, enables debugging again for the lwc language client.

### What issues does this PR fix or reference?
@[W-10537405](https://gus.my.salesforce.com/a07EE00000l2RUFYA2)@

### Functionality Before
Unable to set break points and debug changes in the lighnting-language-server due to a port conflict with the soql language server.

### Functionality After
Breakpoints working again!
