### PR TITLE
feat: add iterator syntax

### DIFF
--- a/packages/lwc-language-server/scripts/convert.js
+++ b/packages/lwc-language-server/scripts/convert.js
@@ -50,26 +50,71 @@ const tags = Object.keys(data).map(key => {
     };
 });
 
+//make globalAttribute changes here, not in standard-lwc.json as they'll be overwritten
 const globalAttributes = [
     {
         name: 'for:each',
-        decription: 'Renders the element or template block multiple times based on the expression value.',
+        description: 'Renders the element or template block multiple times based on the expression value.',
+        references: [
+            {
+                name: 'Salesforce',
+                url: 'https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives',
+            },
+        ],
     },
     {
         name: 'for:item',
-        decription: 'Bind the current iteration item to an identifier.',
+        description: 'Bind the current iteration item to an identifier.',
+        references: [
+            {
+                name: 'Salesforce',
+                url: 'https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives',
+            },
+        ],
     },
     {
         name: 'for:index',
-        decription: 'Bind the current iteration index to an identifier.',
+        description: 'Bind the current iteration index to an identifier.',
+        references: [
+            {
+                name: 'Salesforce',
+                url: 'https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives',
+            },
+        ],
     },
     {
         name: 'if:true',
-        decription: 'Renders the element or template if the expression value is thruthy.',
+        description: 'Renders the element or template if the expression value is truthy.',
+        references: [
+            {
+                name: 'Salesforce',
+                url: 'https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives',
+            },
+        ],
     },
     {
         name: 'if:false',
-        decription: 'Renders the element or template if the expression value is falsy.',
+        description: 'Renders the element or template if the expression value is falsy.',
+        references: [
+            {
+                name: 'Salesforce',
+                url: 'https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives',
+            },
+        ],
+    },
+    {
+        name: 'iterator:it',
+        description: {
+            kind: 'markdown',
+            value:
+                'Bind the current iteration item to an identifier. Contains properties (`value`, `index`, `first`, `last`) that let you apply special behaviors to certain items.',
+        },
+        references: [
+            {
+                name: 'Salesforce',
+                url: 'https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives',
+            },
+        ],
     },
 ];
 

--- a/packages/lwc-language-server/scripts/convert.js
+++ b/packages/lwc-language-server/scripts/convert.js
@@ -50,7 +50,7 @@ const tags = Object.keys(data).map(key => {
     };
 });
 
-//make globalAttribute changes here, not in standard-lwc.json as they'll be overwritten
+// make globalAttribute changes here, not in standard-lwc.json as they'll be overwritten
 const globalAttributes = [
     {
         name: 'for:each',

--- a/packages/lwc-language-server/src/__tests__/lwc-data-provider.test.ts
+++ b/packages/lwc-language-server/src/__tests__/lwc-data-provider.test.ts
@@ -25,3 +25,17 @@ describe('provideValues()', () => {
         expect(names).toInclude('iconName');
     });
 });
+
+describe('provideAttributes()', () => {
+    it('should return a set list of attributes for template tag', () => {
+        const attributes = provider.provideAttributes('template');
+        expect(attributes).not.toBeEmpty();
+        expect(attributes).toBeArrayOfSize(6);
+        expect(attributes[0].name).toEqual('for:each');
+        expect(attributes[1].name).toEqual('for:item');
+        expect(attributes[2].name).toEqual('for:index');
+        expect(attributes[3].name).toEqual('if:true');
+        expect(attributes[4].name).toEqual('if:false');
+        expect(attributes[5].name).toEqual('iterator:it');
+    });
+});

--- a/packages/lwc-language-server/src/resources/standard-lwc.json
+++ b/packages/lwc-language-server/src/resources/standard-lwc.json
@@ -3649,23 +3649,66 @@
   "globalAttributes": [
     {
       "name": "for:each",
-      "decription": "Renders the element or template block multiple times based on the expression value."
+      "description": "Renders the element or template block multiple times based on the expression value.",
+      "references": [
+        {
+          "name": "Salesforce",
+          "url": "https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives"
+        }
+      ]
     },
     {
       "name": "for:item",
-      "decription": "Bind the current iteration item to an identifier."
+      "description": "Bind the current iteration item to an identifier.",
+      "references": [
+        {
+          "name": "Salesforce",
+          "url": "https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives"
+        }
+      ]
     },
     {
       "name": "for:index",
-      "decription": "Bind the current iteration index to an identifier."
+      "description": "Bind the current iteration index to an identifier.",
+      "references": [
+        {
+          "name": "Salesforce",
+          "url": "https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives"
+        }
+      ]
     },
     {
       "name": "if:true",
-      "decription": "Renders the element or template if the expression value is thruthy."
+      "description": "Renders the element or template if the expression value is truthy.",
+      "references": [
+        {
+          "name": "Salesforce",
+          "url": "https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives"
+        }
+      ]
     },
     {
       "name": "if:false",
-      "decription": "Renders the element or template if the expression value is falsy."
+      "description": "Renders the element or template if the expression value is falsy.",
+      "references": [
+        {
+          "name": "Salesforce",
+          "url": "https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives"
+        }
+      ]
+    },
+    {
+      "name": "iterator:it",
+      "description": {
+        "kind": "markdown",
+        "value": "Bind the current iteration item to an identifier. Contains properties (`value`, `index`, `first`, `last`) that let you apply special behaviors to certain items."
+      },
+      "references": [
+        {
+          "name": "Salesforce",
+          "url": "https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?
Added the iterator:it template directive to suggested attributes with others like for:each and
if:true. Fixed issue where description wasn't showing on any of the directives, and added links to
our docs as well. This also allow for flexible syntax, where the user wants to use another variable 
for 'it'.

### What issues does this PR fix or reference?
@W-10536569@, @W-10542295@

### What was the behavior before?
The template directive iterator:it was not appearing in our list of auto-complete attributes, and description information was broken.

### What was the behavior now?
The directive appears, and the description information is now available for all other template directives. 🎉