### PR TITLE
fix: Prevent excessive autocompletion in template JS files

### DIFF
--- a/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
+++ b/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
@@ -10,6 +10,10 @@ const filename = path.resolve('../../test-workspaces/sfdx-workspace/force-app/ma
 const uri = URI.file(filename).toString();
 const document: TextDocument = TextDocument.create(uri, 'html', 0, fsExtra.readFileSync(filename).toString());
 
+const jsFilename = path.resolve('../../test-workspaces/sfdx-workspace/force-app/main/default/lwc/todo/todo.js');
+const jsUri = URI.file(jsFilename).toString();
+const jsDocument: TextDocument = TextDocument.create(uri, 'javascript', 0, fsExtra.readFileSync(jsFilename).toString());
+
 const auraFilename = path.resolve('../../test-workspaces/sfdx-workspace/force-app/main/default/aura/todoApp/todoApp.app');
 const auraUri = URI.file(auraFilename).toString();
 const auraDocument: TextDocument = TextDocument.create(auraFilename, 'html', 0, fsExtra.readFileSync(auraFilename).toString());
@@ -41,6 +45,7 @@ jest.mock('vscode-languageserver', () => {
                 get: (name: string): TextDocument => {
                     const docs = new Map([
                         [uri, document],
+                        [jsUri, jsDocument],
                         [auraUri, auraDocument],
                         [hoverUri, hoverDocument],
                     ]);
@@ -76,6 +81,64 @@ describe('handlers', () => {
     describe('#onCompletion', () => {
         it('should return a list of available completion items in a javascript file', async () => {
             const params: CompletionParams = {
+                textDocument: { uri: jsUri },
+                position: {
+                    line: 0,
+                    character: 0,
+                },
+                context: {
+                    triggerCharacter: '.',
+                    triggerKind: 2,
+                },
+            };
+
+            await server.onInitialize(initializeParams);
+            const completions = await server.onCompletion(params);
+            const labels = completions.items.map(item => item.label);
+            expect(labels).toBeArrayOfSize(8);
+            expect(labels).toInclude('c/todo_util');
+            expect(labels).toInclude('c/todo_item');
+        });
+
+        it('should not return a list of completion items in a javascript file for open curly brace', async () => {
+            const params: CompletionParams = {
+                textDocument: { uri: jsUri },
+                position: {
+                    line: 0,
+                    character: 0,
+                },
+                context: {
+                    triggerCharacter: '{',
+                    triggerKind: 2,
+                },
+            };
+
+            await server.onInitialize(initializeParams);
+            const completions = await server.onCompletion(params);
+            expect(completions.items).toBeEmpty();
+        });
+
+        it('returns a list of available tag completion items in a LWC template', async () => {
+            const params: CompletionParams = {
+                textDocument: { uri },
+                position: {
+                    line: 16,
+                    character: 30,
+                },
+            };
+
+            await server.onInitialize(initializeParams);
+            const completions = await server.onCompletion(params);
+            const labels = completions.items.map(item => item.label);
+            expect(labels).toInclude('c-todo_item');
+            expect(labels).toInclude('c-todo');
+            expect(labels).toInclude('lightning-icon');
+            expect(labels).not.toInclude('div');
+            expect(labels).not.toInclude('lightning:icon'); // this is handled by the aura Lang. server
+        });
+
+        it('should return a list of available attribute completion items in a LWC template', async () => {
+            const params: CompletionParams = {
                 textDocument: { uri },
                 position: {
                     line: 0,
@@ -93,25 +156,6 @@ describe('handlers', () => {
             expect(labels).toBeArrayOfSize(19);
             expect(labels).toInclude('handleToggleAll');
             expect(labels).toInclude('handleClearCompleted');
-        });
-
-        it('returns a list of available completion items in a LWC template', async () => {
-            const params: CompletionParams = {
-                textDocument: { uri },
-                position: {
-                    line: 16,
-                    character: 30,
-                },
-            };
-
-            await server.onInitialize(initializeParams);
-            const completions = await server.onCompletion(params);
-            const labels = completions.items.map(item => item.label);
-            expect(labels).toInclude('c-todo_item');
-            expect(labels).toInclude('c-todo');
-            expect(labels).toInclude('lightning-icon');
-            expect(labels).not.toInclude('div');
-            expect(labels).not.toInclude('lightning:icon'); // this is handled by the aura Lang. server
         });
 
         it('returns a list of available completion items in a Aura template', async () => {

--- a/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
+++ b/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
@@ -1,6 +1,15 @@
 import Server, { Token, findDynamicContent } from '../lwc-server';
 import { getLanguageService } from 'vscode-html-languageservice';
-import { TextDocument, InitializeParams, TextDocumentPositionParams, Location, MarkupContent, Hover, CompletionParams } from 'vscode-languageserver';
+import {
+    TextDocument,
+    InitializeParams,
+    TextDocumentPositionParams,
+    Location,
+    MarkupContent,
+    Hover,
+    CompletionParams,
+    CompletionTriggerKind,
+} from 'vscode-languageserver';
 
 import { URI } from 'vscode-uri';
 import * as fsExtra from 'fs-extra';
@@ -88,7 +97,7 @@ describe('handlers', () => {
                 },
                 context: {
                     triggerCharacter: '.',
-                    triggerKind: 2,
+                    triggerKind: CompletionTriggerKind.TriggerCharacter,
                 },
             };
 
@@ -109,13 +118,13 @@ describe('handlers', () => {
                 },
                 context: {
                     triggerCharacter: '{',
-                    triggerKind: 2,
+                    triggerKind: CompletionTriggerKind.TriggerCharacter,
                 },
             };
 
             await server.onInitialize(initializeParams);
             const completions = await server.onCompletion(params);
-            expect(completions.items).toBeEmpty();
+            expect(completions).toBeUndefined();
         });
 
         it('returns a list of available tag completion items in a LWC template', async () => {
@@ -146,7 +155,7 @@ describe('handlers', () => {
                 },
                 context: {
                     triggerCharacter: '{',
-                    triggerKind: 2,
+                    triggerKind: CompletionTriggerKind.TriggerCharacter,
                 },
             };
 

--- a/packages/lwc-language-server/src/lwc-server.ts
+++ b/packages/lwc-language-server/src/lwc-server.ts
@@ -150,17 +150,19 @@ export default class Server {
                 };
             }
         } else if (await this.context.isLWCJavascript(doc)) {
-            const customTags = this.componentIndexer.customData.map(tag => {
-                return {
-                    label: tag.lwcTypingsName,
-                    kind: CompletionItemKind.Folder,
-                };
-            });
+            if (this.shouldCompleteJavascript(params)) {
+                const customTags = this.componentIndexer.customData.map(tag => {
+                    return {
+                        label: tag.lwcTypingsName,
+                        kind: CompletionItemKind.Folder,
+                    };
+                });
 
-            return {
-                isIncomplete: false,
-                items: customTags,
-            };
+                return {
+                    isIncomplete: false,
+                    items: customTags,
+                };
+            }
         } else if (await this.context.isAuraMarkup(doc)) {
             this.auraDataProvider.activated = true;
             this.lwcDataProvider.activated = false;

--- a/packages/lwc-language-server/src/lwc-server.ts
+++ b/packages/lwc-language-server/src/lwc-server.ts
@@ -141,7 +141,7 @@ export default class Server {
         if (await this.context.isLWCTemplate(doc)) {
             this.auraDataProvider.activated = false; // provide completions for lwc components in an Aura template
             this.lwcDataProvider.activated = true;
-            if (params.context?.triggerCharacter === '{') {
+            if (this.shouldProvideBindingsInHTML(params)) {
                 const docBasename = utils.getBasename(doc);
                 const customTags: CompletionItem[] = this.findBindItems(docBasename);
                 return {
@@ -168,6 +168,14 @@ export default class Server {
             return;
         }
         return this.languageService.doComplete(doc, position, htmlDoc);
+    }
+
+    private shouldProvideBindingsInHTML(params: CompletionParams): boolean {
+        return params.context?.triggerCharacter === '{';
+    }
+
+    private shouldCompleteJavascript(params: CompletionParams): boolean {
+        return params.context?.triggerCharacter !== '{';
     }
 
     private findBindItems(docBasename: string): CompletionItem[] {

--- a/packages/lwc-language-server/src/lwc-server.ts
+++ b/packages/lwc-language-server/src/lwc-server.ts
@@ -162,6 +162,8 @@ export default class Server {
                     isIncomplete: false,
                     items: customTags,
                 };
+            } else {
+                return;
             }
         } else if (await this.context.isAuraMarkup(doc)) {
             this.auraDataProvider.activated = true;


### PR DESCRIPTION
### What does this PR do?
- Addresses a recent issue where we were providing autocomplete for curly braces in JS files, when we really only wanted to do so in HTML. This caused annoying and unhelpful autocomplete due to them firing off every time a conditional statement or method was declared. This reverts the JS autocomplete to how it was previously with a bit more semantic method naming to make it clear what the trigger characters are doing.

### What issues does this PR fix or reference?
VS Code #3902. @W-10832653@