### PR TITLE
chore: update volta node/yarn versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "js-yaml": "^3.13.1"
   },
   "volta": {
-    "node": "12.4.0",
-    "yarn": "1.22.4"
+    "node": "12.22.12",
+    "yarn": "1.22.18"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
### What does this PR do?

If you run `yarn install` on a fresh clone of this repo, and you have Volta installed, you will get an error:

```
error jest-diff@27.4.6: The engine "node" is incompatible with this module. Expected version "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0". Got "12.4.0"
error Found incompatible module.
```

The reason is that the Volta node version is out of date. I bumped it, as well as the yarn version (just because we might as well).

### What issues does this PR fix or reference?

N/A