### PR TITLE
fix: handle malformed tags quietly

### DIFF
--- a/packages/lwc-language-server/src/__tests__/tag.test.ts
+++ b/packages/lwc-language-server/src/__tests__/tag.test.ts
@@ -181,4 +181,28 @@ describe('Tag', () => {
             });
         });
     });
+
+    describe('handling malformed Tag', () => {
+        /**
+         * TODO: With the outdated version of the lwc compiler, the NavigationMixin
+         * isn't being compiled correctly. This test and the optional classMember
+         * check in Tag should be removed after upgrading.
+         */
+        let tag: Tag;
+        const fileWithErrors = './src/javascript/__tests__/fixtures/navmetadata.js';
+
+        beforeEach(async () => {
+            tag = await Tag.fromFile(fileWithErrors);
+        });
+
+        it('does not throw an error when finding a class member location without class members', () => {
+            let exception;
+            try {
+                tag.classMemberLocation('account');
+            } catch (error) {
+                exception = error;
+            }
+            expect(exception).toBeUndefined();
+        });
+    });
 });

--- a/packages/lwc-language-server/src/__tests__/tag.test.ts
+++ b/packages/lwc-language-server/src/__tests__/tag.test.ts
@@ -185,8 +185,7 @@ describe('Tag', () => {
     describe('handling malformed Tag', () => {
         /**
          * TODO: With the outdated version of the lwc compiler, the NavigationMixin
-         * isn't being compiled correctly. This test and the optional classMember
-         * check in Tag should be removed after upgrading.
+         * isn't being compiled correctly. This test should be updated after upgrading.
          */
         let tag: Tag;
         const fileWithErrors = './src/javascript/__tests__/fixtures/navmetadata.js';

--- a/packages/lwc-language-server/src/javascript/__tests__/fixtures/navmetadata.js
+++ b/packages/lwc-language-server/src/javascript/__tests__/fixtures/navmetadata.js
@@ -1,0 +1,18 @@
+import { LightningElement, api } from 'lwc';
+import { NavigationMixin } from 'lightning/navigation';
+import AccountObj from '@salesforce/schema/Account';
+
+export default class NavMetadata extends NavigationMixin(LightningElement) {
+    @api account;
+
+    handleAccountClick() {
+        this[NavigationMixin.Navigate]({
+            type: 'standard__recordPage',
+            attributes: {
+                recordId: this.account.Id,
+                objectApiName: AccountObj.objectApiName,
+                actionName: 'view',
+            },
+        });
+    }
+}

--- a/packages/lwc-language-server/src/tag.ts
+++ b/packages/lwc-language-server/src/tag.ts
@@ -117,7 +117,7 @@ export default class Tag implements ITagData {
     }
 
     classMember(name: string): ClassMember | null {
-        return this.classMembers.find(item => item.name === name) || null;
+        return this.classMembers?.find(item => item.name === name) || null;
     }
 
     classMemberLocation(name: string): Location | null {

--- a/packages/lwc-language-server/src/tag.ts
+++ b/packages/lwc-language-server/src/tag.ts
@@ -123,6 +123,7 @@ export default class Tag implements ITagData {
     classMemberLocation(name: string): Location | null {
         const classMember = this.classMember(name);
         if (!classMember) {
+            console.log(`Attribute "${name}" not found`);
             return null;
         }
         return Location.create(this.uri, toVSCodeRange(classMember?.loc));


### PR DESCRIPTION
### What does this PR do?
Suppresses a noisy exception that occurs when trying to use the Hover or Go To Definition functionality on a component that we are not able to compile correctly due to the outdated LWC Compiler. One example of this error occurs when a component is using the NavigationMixin. This error is now logged quietly in the LWC output panel instead, so we can receive better reports from our users around the type of components that are not being handled correctly.

### What issues does this PR fix or reference?
#493 

### Notes
To test, open the ebikes-LWC repo, or another project using the NavigationMixin. For the ebikes repo, open the productListItem, hover over the {product.MSRP__C} (or any other attribute) and press Cmd to try and click through to the definition. The error `Request textDocument/definition failed. Message: Request textDocument/definition failed with message: Cannot read properties of undefined (reading 'find')` will appear. Reload with the changes, and verify that there is no pronounced error grabbing focus. The error is logged in the LWC output tab instead:

![Screen Shot 2022-06-02 at 4 15 25 PM](https://user-images.githubusercontent.com/9795193/171730236-62e1a1ec-4244-4222-b984-ead634e9dc2e.png)

For an example of how the feature is supposed to work, open the accountMap and Cmd+Click to go to the definition of any attribute (like `markers`).