### PR TITLE
fix: no more double logging to the LWC Lang Server Tab

### DIFF
--- a/packages/lightning-lsp-common/src/logger.ts
+++ b/packages/lightning-lsp-common/src/logger.ts
@@ -11,9 +11,9 @@ export function interceptConsoleLogger(connection: IConnection): void {
             if (connection) {
                 const remote: any = connection.console;
                 remote[method].apply(connection.console, args);
+            } else {
+                original.apply(console, args);
             }
-
-            original.apply(console, args);
         };
     };
     const methods = ['log', 'info', 'warn', 'error'];


### PR DESCRIPTION
### What does this PR do?
- Gets rid of the double logging to the LWC Language Server Output Tab when Attribute Not Found

### What issues does this PR fix or reference?
[@W-11307712@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000zN76PYAS/view)

### Functionality Before
- "Attribute x not found" was being logged twice per each cmd+click/hover when applicable

### Functionality After
- "Attribute x not found" is being logged once per each cmd+click/hover when applicable