### PR TITLE
ci: update preCommit script to be a commonjs module

### DIFF
--- a/scripts/bump-lerna-version.js
+++ b/scripts/bump-lerna-version.js
@@ -7,7 +7,7 @@
 
 const shell = require("shelljs");
 
-export function preCommit(props) {
+const preCommit = (props) => {
   if (props && props.version) {
     shell.exec(`yarn`);
     shell.exec(`yarn bump-versions ${props.version}`);
@@ -16,4 +16,6 @@ export function preCommit(props) {
       `git commit --allow-empty -m "chore: updated version ${props.version} [ci skip]"`
     );
   }
-}
+};
+
+exports.preCommit = preCommit;


### PR DESCRIPTION
### What does this PR do?
Reviewing the failure of the release job in CI and started looking at docs for conventional-changelog-action.  Found we have some unmet requirements around the preCommit [here](https://github.com/TriPSs/conventional-changelog-action#pre-commit-hook).  It still may fail but get further due to us having the shelljs dependancy. 

### What issues does this PR fix or reference?
#521 continued