### PR TITLE
ci: simplify onRelease GHA

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -1,9 +1,8 @@
-name: release
-
+name: npm release
+# when a github release happens, publish an npm package,
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types: [released]
 
 jobs:
   publish:
@@ -11,12 +10,9 @@ jobs:
     container:
       image: node:lts
     steps:
-    - uses: actions/checkout@v2
-  npm:
-    runs-on: ubuntu-latest
-    container:
-      image: node:lts
-    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.IDEE_GH_TOKEN }}
       - name: Set .npmrc
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - run: yarn publish-lsp


### PR DESCRIPTION
### What does this PR do?
Alter the flow for an NPM release to be after a GH release has been created. 

### What issues does this PR fix or reference?
https://github.com/forcedotcom/lightning-language-server/pull/521 continued @W-11955917@