### PR TITLE
@W-12333642 Add wire adapter type for getProgramTemplate in lightning/salesEnablementProgramApi

### DIFF
--- a/packages/lightning-lsp-common/src/resources/sfdx/typings/lds.d.ts
+++ b/packages/lightning-lsp-common/src/resources/sfdx/typings/lds.d.ts
@@ -625,6 +625,13 @@ declare module 'lightning/salesEnablementProgramApi' {
      * Wire adapter for getting Sales Enablement Program templates list.
      */
     export function getProgramTemplates(): void;
+
+    /**
+     * Wire adapter for getting Sales Enablement Program details of the programTemplateName passed as url param.
+     * @param programTemplateName name of the template for which details are required
+     */
+     
+         export function getProgramTemplate(programTemplateName: string): void;
 }
 
 declare module 'lightning/analyticsWaveApi' {


### PR DESCRIPTION
### What does this PR do?
Add wire adapter type for getProgramTemplate in lightning/salesEnablementProgramApi .

### What issues does this PR fix or reference?
