### PR TITLE
ci: update manual release and push to main to allow for nvmrc usage

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -1,4 +1,4 @@
-name: Push to main
+name: Push to Main
 
 on:
   push:
@@ -12,12 +12,12 @@ jobs:
     needs:
     - tests
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.IDEE_GH_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
       - run: yarn
       - name: Conventional Changelog Action
         id: changelog

--- a/.github/workflows/startManualRelease.yml
+++ b/.github/workflows/startManualRelease.yml
@@ -8,12 +8,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.IDEE_GH_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
       - run: yarn
       - name: Conventional Changelog Action
         id: changelog


### PR DESCRIPTION
### What does this PR do?
Swaps the order of checkout and node setup in 2 github actions so we can use the nvmrc of the checked out code to determine the node version used.

### What issues does this PR fix or reference?
Follow-up fix to #549 