### PR TITLE
fix(core): update core config file and handle read errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
    let you know if there is already an effort in progress.
 1. Fork this repository.
 1. The [README](README.md) has details on how to set up your environment.
-1. Create a _topic_ branch in your fork based on the correct branch (usually the **develop** branch, see [Branches section](#branches) below). Note, this step is recommended but technically not required if contributing using a fork.
+1. Create a _topic_ branch in your fork based on the correct branch (usually the **main** branch, see [Branches section](#branches) below). Note, this step is recommended but technically not required if contributing using a fork.
 1. Edit the code in your fork.
 1. Sign CLA (see [CLA](#cla) below)
 1. Send us a pull request when you are done. We'll review your code, suggest any
@@ -26,10 +26,10 @@ Agreement. You can do so by going to https://cla.salesforce.com/sign-cla.
 
 ## Branches
 
-- We work in `develop`.
+- We work in `main`.
 - Our released (aka. _production_) branch is `main`.
 - Our work happens in _topic_ branches (feature and/or bug-fix).
-  - feature as well as bug-fix branches are based on `develop`
+  - feature as well as bug-fix branches are based on `main`
   - branches _should_ be kept up-to-date using `rebase`
   - see below for further merge instructions
 
@@ -41,24 +41,11 @@ Agreement. You can do so by going to https://cla.salesforce.com/sign-cla.
 
 - _Topic_ branches are:
 
-  1. based on `develop` and will be
-  1. squash-merged into `develop`.
+  1. based on `main` and will be
+  1. squash-merged into `main`.
 
 - Hot-fix branches are an exception.
   - Instead we aim for faster cycles and a generally stable `develop` branch.
-
-### Merging `develop` into `main`
-
-- When a development cycle finishes, the content of the `develop` branch will become the `main` branch
-
-```
-$ git checkout main
-$ git reset --hard develop
-$
-$ # Using a custom commit message for the merge below
-$ git merge -m 'Merge -s our (where _ours_ is develop) releasing stream x.y.z.' -s ours origin/main
-$ git push origin main
-```
 
 ## Pull Requests
 

--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -13,6 +13,13 @@ import {
     CORE_MULTI_ROOT,
 } from './test-utils';
 
+beforeAll(() => {
+    // make sure test runner config doesn't overlap with test workspace
+    delete process.env.P4PORT;
+    delete process.env.P4CLIENT;
+    delete process.env.P4USER;
+});
+
 it('WorkspaceContext', async () => {
     let context = new WorkspaceContext('test-workspaces/sfdx-workspace');
     expect(context.type).toBe(WorkspaceType.SFDX);
@@ -253,8 +260,9 @@ it('configureCoreProject()', async () => {
     const settingsPath = CORE_PROJECT_ROOT + '/.vscode/settings.json';
 
     // make sure no generated files are there from previous runs
-    fs.removeSync(jsconfigPath);
-    fs.removeSync(typingsPath);
+    await fs.remove(jsconfigPath);
+    await fs.remove(typingsPath);
+    await fs.remove(settingsPath);
 
     // configure and verify typings/jsconfig after configuration:
     await context.configureProject();
@@ -262,7 +270,7 @@ it('configureCoreProject()', async () => {
     verifyJsconfigCore(jsconfigPath);
     verifyTypingsCore();
 
-    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
     verifyCoreSettings(settings);
 });
 

--- a/packages/lightning-lsp-common/src/context.ts
+++ b/packages/lightning-lsp-common/src/context.ts
@@ -452,7 +452,7 @@ export class WorkspaceContext {
         try {
             configBlt = await this.readConfigBlt();
         } catch (error) {
-            console.warn("Error reading core config", configBlt);
+            console.warn(`Error reading core config. Expected for git repos. ${error}`);
             return;
         }
         const variableMap = {
@@ -474,7 +474,7 @@ export class WorkspaceContext {
         try {
             configBlt = await this.readConfigBlt();
         } catch (error) {
-            console.warn("Error reading core config", configBlt);
+            console.warn(`Error reading core config. Expected for git repos. ${error}`);
             return;
         }
         const variableMap = {
@@ -488,8 +488,14 @@ export class WorkspaceContext {
         this.updateConfigFile('core.code-workspace', templateContent);
     }
 
-    private async readConfigBlt(): Promise<{[key:string]: string}> {
-        const devProperties = path.join(this.workspaceRoots[0], 'build', 'dev.properties');
+    private async readConfigBlt(): Promise<{ [key: string]: string }> {
+        let devProperties;
+        if (this.type === WorkspaceType.CORE_PARTIAL) {
+            // most common because this is the workspace corecli generates
+            devProperties = path.join(this.workspaceRoots[0], '..', 'build', 'dev.properties');
+        } else if (this.type === WorkspaceType.CORE_ALL) {
+            devProperties = path.join(this.workspaceRoots[0], 'build', 'dev.properties');
+        }
         const configBltContent = await fs.readFile(devProperties, 'utf8');
         return parse(configBltContent);
     }

--- a/packages/lightning-lsp-common/src/context.ts
+++ b/packages/lightning-lsp-common/src/context.ts
@@ -448,7 +448,13 @@ export class WorkspaceContext {
     }
 
     private async updateCoreSettings(): Promise<void> {
-        const configBlt = await this.readConfigBlt();
+        let configBlt;
+        try {
+            configBlt = await this.readConfigBlt();
+        } catch (error) {
+            console.warn("Error reading core config", configBlt);
+            return;
+        }
         const variableMap = {
             eslint_node_path: await findCoreESLint(),
             p4_port: configBlt['p4.port'],
@@ -464,7 +470,13 @@ export class WorkspaceContext {
     }
 
     private async updateCoreCodeWorkspace(): Promise<void> {
-        const configBlt = await this.readConfigBlt();
+        let configBlt;
+        try {
+            configBlt = await this.readConfigBlt();
+        } catch (error) {
+            console.warn("Error reading core config", configBlt);
+            return;
+        }
         const variableMap = {
             eslint_node_path: await findCoreESLint(),
             p4_port: configBlt['p4.port'],
@@ -476,13 +488,9 @@ export class WorkspaceContext {
         this.updateConfigFile('core.code-workspace', templateContent);
     }
 
-    private async readConfigBlt(): Promise<any> {
-        const isMain = this.workspaceRoots[0].indexOf(path.join('main', 'core')) !== -1;
-        let relativeBltDir = isMain ? path.join('..', '..', '..') : path.join('..', '..', '..', '..');
-        if (this.type === WorkspaceType.CORE_PARTIAL) {
-            relativeBltDir = path.join(relativeBltDir, '..');
-        }
-        const configBltContent = await fs.readFile(path.join(this.workspaceRoots[0], relativeBltDir, 'config.blt'), 'utf8');
+    private async readConfigBlt(): Promise<{[key:string]: string}> {
+        const devProperties = path.join(this.workspaceRoots[0], 'build', 'dev.properties');
+        const configBltContent = await fs.readFile(devProperties, 'utf8');
         return parse(configBltContent);
     }
 

--- a/test-workspaces/core-like-workspace/app/main/core/build/user.properties
+++ b/test-workspaces/core-like-workspace/app/main/core/build/user.properties
@@ -1,4 +1,4 @@
 p4.user = username
 p4.client = username-localhost-blt
 p4.port = ssl:host:port
-eclipse.default.jdk = path_to_java_home
+eclipse.default.jdk = path_to_java_homes


### PR DESCRIPTION
The core config file containing environment variables is now build/dev.properties. Use that file instead of config.blt. Additionally handle any errors in parsing and reading by logging to console and not attempting to write to the file.

Fixes [@W-13007946@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001OplXFYAZ/view). Fixes #497.