### PR TITLE
Update community-contributor label to open Work

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -6,7 +6,8 @@
   },
   "issueTypeLabels": {
     "bug": "BUG P3",
-    "security": "BUG P2"
+    "security": "BUG P2",
+    "type:community-contrib": "USER STORY"
   },
   "defaultBuild": "offcore.tooling.54.0.0",
   "hideWorkItemUrl": "true",


### PR DESCRIPTION
### What does this PR do?

Adding the tag "community-contributor" should create a WI in our internal bug tracker. 

### What issues does this PR fix or reference?

Fixes forcedotcom/easywriter#155. [@W-13013847@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Ou3OUYAZ/view).