### PR TITLE
feat: add new lwc directives as autocomplete options in 242/258

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm run compile
 Note: complete the install process before this step, or you may receive errors about "Property ‘objType’ does not exist on type ‘Node’." from the Tern Server. This is due to the node_modules being improperly installed at a level above the lightning-language-server. If this does happen to you, simply remove the extra node_modules directory.
 
 ```
-cd lightning-language-server
+cd ../lightning-language-server
 code ./vscode-workspaces/multiroot-simple.code-workspace # or
 code ./vscode-workspaces/multiroot-flat.code-workspace
 ```

--- a/packages/lwc-language-server/scripts/convert.js
+++ b/packages/lwc-language-server/scripts/convert.js
@@ -94,7 +94,37 @@ const globalAttributes = [
     },
     {
         name: 'if:false',
-        description: 'Renders the element or template if the expression value is falsy.',
+        description: 'Renders the element or template if the expression value is falsy. This directive is deprecated and no longer recommended. It may be removed in the future. Use lwc:if, lwc:elseif, and lwc:else instead.',
+        references: [
+            {
+                name: 'Salesforce',
+                url: 'https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives',
+            },
+        ],
+    },
+    {
+        name: 'lwc:if',
+        description: 'Renders the element or template if the expression value is truthy. This directive is deprecated and no longer recommended. It may be removed in the future. Use lwc:if, lwc:elseif, and lwc:else instead.',
+        references: [
+            {
+                name: 'Salesforce',
+                url: 'https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives',
+            },
+        ],
+    },
+    {
+        name: 'lwc:elseif',
+        description: 'Renders the element or template if the expression value is truthy.',
+        references: [
+            {
+                name: 'Salesforce',
+                url: 'https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives',
+            },
+        ],
+    },
+    {
+        name: 'lwc:else',
+        description: 'Renders the element or template if none of the expressions values of the preceding lwc:if or lwc:elseif are truthy.',
         references: [
             {
                 name: 'Salesforce',

--- a/packages/lwc-language-server/scripts/convert.js
+++ b/packages/lwc-language-server/scripts/convert.js
@@ -84,7 +84,7 @@ const globalAttributes = [
     },
     {
         name: 'if:true',
-        description: 'Renders the element or template if the expression value is truthy.',
+        description: 'Renders the element or template if the expression value is truthy. This directive is deprecated and no longer recommended. It may be removed in the future. Use lwc:if, lwc:elseif, and lwc:else instead.',
         references: [
             {
                 name: 'Salesforce',
@@ -104,7 +104,7 @@ const globalAttributes = [
     },
     {
         name: 'lwc:if',
-        description: 'Renders the element or template if the expression value is truthy. This directive is deprecated and no longer recommended. It may be removed in the future. Use lwc:if, lwc:elseif, and lwc:else instead.',
+        description: 'Renders the element or template if the expression value is truthy.',
         references: [
             {
                 name: 'Salesforce',

--- a/packages/lwc-language-server/src/__tests__/lwc-data-provider.test.ts
+++ b/packages/lwc-language-server/src/__tests__/lwc-data-provider.test.ts
@@ -59,12 +59,15 @@ describe('provideAttributes()', () => {
     it('should return a set list of attributes for template tag', () => {
         const attributes = provider.provideAttributes('template');
         expect(attributes).not.toBeEmpty();
-        expect(attributes).toBeArrayOfSize(6);
+        expect(attributes).toBeArrayOfSize(9);
         expect(attributes[0].name).toEqual('for:each');
         expect(attributes[1].name).toEqual('for:item');
         expect(attributes[2].name).toEqual('for:index');
         expect(attributes[3].name).toEqual('if:true');
         expect(attributes[4].name).toEqual('if:false');
-        expect(attributes[5].name).toEqual('iterator:it');
+        expect(attributes[5].name).toEqual('lwc:if');
+        expect(attributes[6].name).toEqual('lwc:elseif');
+        expect(attributes[7].name).toEqual('lwc:else');
+        expect(attributes[8].name).toEqual('iterator:it');
     });
 });

--- a/packages/lwc-language-server/src/resources/standard-lwc.json
+++ b/packages/lwc-language-server/src/resources/standard-lwc.json
@@ -3689,7 +3689,37 @@
     },
     {
       "name": "if:false",
-      "description": "Renders the element or template if the expression value is falsy.",
+      "description": "Renders the element or template if the expression value is falsy. This directive is deprecated and no longer recommended. It may be removed in the future. Use lwc:if, lwc:elseif, and lwc:else instead.",
+      "references": [
+        {
+          "name": "Salesforce",
+          "url": "https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives"
+        }
+      ]
+    },
+    {
+      "name": "lwc:if",
+      "description": "Renders the element or template if the expression value is truthy. This directive is deprecated and no longer recommended. It may be removed in the future. Use lwc:if, lwc:elseif, and lwc:else instead.",
+      "references": [
+        {
+          "name": "Salesforce",
+          "url": "https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives"
+        }
+      ]
+    },
+    {
+      "name": "lwc:elseif",
+      "description": "Renders the element or template if the expression value is truthy.",
+      "references": [
+        {
+          "name": "Salesforce",
+          "url": "https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_directives"
+        }
+      ]
+    },
+    {
+      "name": "lwc:else",
+      "description": "Renders the element or template if none of the expressions values of the preceding lwc:if or lwc:elseif are truthy.",
       "references": [
         {
           "name": "Salesforce",

--- a/packages/lwc-language-server/src/resources/standard-lwc.json
+++ b/packages/lwc-language-server/src/resources/standard-lwc.json
@@ -3679,7 +3679,7 @@
     },
     {
       "name": "if:true",
-      "description": "Renders the element or template if the expression value is truthy.",
+      "description": "Renders the element or template if the expression value is truthy. This directive is deprecated and no longer recommended. It may be removed in the future. Use lwc:if, lwc:elseif, and lwc:else instead.",
       "references": [
         {
           "name": "Salesforce",
@@ -3699,7 +3699,7 @@
     },
     {
       "name": "lwc:if",
-      "description": "Renders the element or template if the expression value is truthy. This directive is deprecated and no longer recommended. It may be removed in the future. Use lwc:if, lwc:elseif, and lwc:else instead.",
+      "description": "Renders the element or template if the expression value is truthy.",
       "references": [
         {
           "name": "Salesforce",


### PR DESCRIPTION
### What does this PR do?
Adds support (for autocomplete as well) to the following new LWC directives that were released with 242:
- lwc:if
- lwc:elseif
- lwc:else

### What issues does this PR fix or reference?
@W-12051474@

### Functionality after
- Autocomplete
![Pasted Graphic 1](https://user-images.githubusercontent.com/113132642/232843798-474e0416-327a-4ec0-b666-3974ae8708a6.png)

- On hover info
![Pasted Graphic](https://user-images.githubusercontent.com/113132642/232843855-c0186504-6607-4cc8-a272-81c8a7564ecf.png)
