### PR TITLE
feat: ensure langauge server does not crash with no default export

### DIFF
--- a/packages/lwc-language-server/src/javascript/__tests__/compiler.test.ts
+++ b/packages/lwc-language-server/src/javascript/__tests__/compiler.test.ts
@@ -61,7 +61,7 @@ it('displays an error for a component with other errors', async () => {
         end: {
             line: 4,
             character: MAX_32BIT_INTEGER,
-        }
+        },
     });
 });
 
@@ -112,10 +112,12 @@ it('mapLwcMetadataToInternal returns expected javascript metadata', async () => 
         name: 'metadata',
         namespace: 'x',
         namespaceMapping: {},
-        files: [{
-            fileName: 'metadata.js',
-            source: content,
-        }],
+        files: [
+            {
+                fileName: 'metadata.js',
+                source: content,
+            },
+        ],
     };
 
     const modernMetadata = collectBundleMetadata(options);
@@ -125,7 +127,7 @@ it('mapLwcMetadataToInternal returns expected javascript metadata', async () => 
     expect(metadata.doc).toBe('* Foo doc');
     expect(metadata.declarationLoc).toEqual({
         start: { column: 0, line: 8 },
-        end: { column: 1, line: 80 }
+        end: { column: 1, line: 80 },
     });
 
     expect(getPublicReactiveProperties(metadata)).toMatchObject([
@@ -141,34 +143,29 @@ it('mapLwcMetadataToInternal returns expected javascript metadata', async () => 
         { name: 'superComplex' },
     ]);
     expect(properties).toMatchObject([
-      { name: 'todo' },
-      { name: 'index' },
-      { name: 'initializedAsApiNumber' },
-      { name: 'initializedAsTrackNumber' },
-      { name: 'indexSameLine' },
-      { name: 'initializedWithImportedVal' },
-      { name: 'arrOfStuff' },
-      { name: 'trackedPrivateIndex' },
-      { name: 'stringVal' },
-      { name: 'trackedThing' },
-      { name: 'trackedArr' },
-      { name: 'callback' },
-      { name: 'fooNull' },
-      { name: 'superComplex' },
-      { name: 'wiredProperty' },
-      { name: 'wiredPropertyWithNestedParam' },
-      { name: 'wiredPropertyWithNestedObjParam' },
-      { name: 'apexWiredProperty' },
-      { name: 'apexWiredInitVal' },
-      { name: 'apexWiredInitArr' },
-      { name: 'privateComputedValue' },
+        { name: 'todo' },
+        { name: 'index' },
+        { name: 'initializedAsApiNumber' },
+        { name: 'initializedAsTrackNumber' },
+        { name: 'indexSameLine' },
+        { name: 'initializedWithImportedVal' },
+        { name: 'arrOfStuff' },
+        { name: 'trackedPrivateIndex' },
+        { name: 'stringVal' },
+        { name: 'trackedThing' },
+        { name: 'trackedArr' },
+        { name: 'callback' },
+        { name: 'fooNull' },
+        { name: 'superComplex' },
+        { name: 'wiredProperty' },
+        { name: 'wiredPropertyWithNestedParam' },
+        { name: 'wiredPropertyWithNestedObjParam' },
+        { name: 'apexWiredProperty' },
+        { name: 'apexWiredInitVal' },
+        { name: 'apexWiredInitArr' },
+        { name: 'privateComputedValue' },
     ]);
-    expect(getMethods(metadata)).toMatchObject([
-        { name: 'onclickAction' },
-        { name: 'apiMethod' },
-        { name: 'myWiredMethod' },
-        { name: 'methodWithArguments' },
-    ]);
+    expect(getMethods(metadata)).toMatchObject([{ name: 'onclickAction' }, { name: 'apiMethod' }, { name: 'myWiredMethod' }, { name: 'methodWithArguments' }]);
 
     expect(getPrivateReactiveProperties(metadata)).toMatchObject([
         { name: 'initializedAsTrackNumber' },
@@ -217,4 +214,32 @@ it('use compileFile()', async () => {
     const { metadata } = await compileFile(filepath);
     const publicProperties = getPublicReactiveProperties(metadata);
     expect(publicProperties).toMatchObject([{ name: 'index' }]);
+});
+
+it('should be able to compile a javascript class that has no default export', async () => {
+    const content = `
+        export class Foo {
+            a = 5;
+        }
+    `;
+
+    const document = TextDocument.create('file:///foo.js', 'javascript', 0, content);
+    const { metadata } = await compileDocument(document);
+
+    expect(metadata).toMatchObject({
+        decorators: [],
+        classMembers: [],
+        doc: '',
+        declarationLoc: {
+            start: {
+                line: 0,
+                column: 0,
+            },
+            end: {
+                line: 0,
+                column: 0,
+            },
+        },
+        exports: [],
+    });
 });

--- a/packages/lwc-language-server/src/javascript/type-mapping.ts
+++ b/packages/lwc-language-server/src/javascript/type-mapping.ts
@@ -541,8 +541,14 @@ function getExports(lwcExports: LwcExport[]): InternalModuleExports[] {
  * LWC language server to analyze code in a user's IDE.
  */
 export function mapLwcMetadataToInternal(lwcMeta: ScriptFile): InternalMetadata {
-    const mainClassObj = lwcMeta.classes.find(classObj => {
-        return classObj.id == lwcMeta.mainClass.refId;
+    const hasLwc = () => lwcMeta.mainClass;
+
+    if (!hasLwc()) {
+        return genEmptyMetadata();
+    }
+
+    const mainClassObj = lwcMeta.classes.find((classObj) => {
+        return lwcMeta.mainClass && classObj.id == lwcMeta.mainClass.refId;
     });
 
     const defaultExport = lwcMeta.exports.filter((exp) => exp.defaultExport)[0];
@@ -558,3 +564,24 @@ export function mapLwcMetadataToInternal(lwcMeta: ScriptFile): InternalMetadata 
 
     return internalMeta;
 }
+
+function genEmptyMetadata() {
+    const internalMeta: InternalMetadata = {
+        decorators: [],
+        classMembers: [],
+        doc: '',
+        declarationLoc: {
+            start: {
+                line: 0,
+                column: 0,
+            },
+            end: {
+                line: 0,
+                column: 0,
+            },
+        },
+        exports: [],
+    };
+    return internalMeta;
+}
+


### PR DESCRIPTION
### What does this PR do?

It ensures that the LWC language server does not crash if an LWC file does not have a default export. 

### What issues does this PR fix or reference?

https://github.com/forcedotcom/salesforcedx-vscode/issues/4994

So, this change works in the following way.

It assumes that the lwc language server is adding information for just the "LWC" portion of a javascript file. (the stuff included in the default export). If it does not find an LWC, it simply returns an "empty" Internal Metadata definition to the vscode language server (since no LWC implies that no metadata information should be added to the language server). 