### PR TITLE
fix: language server would crash if main class could not be identified

### DIFF
--- a/packages/lwc-language-server/src/javascript/__tests__/compiler.test.ts
+++ b/packages/lwc-language-server/src/javascript/__tests__/compiler.test.ts
@@ -33,6 +33,21 @@ export default class Foo extends LightningElement {
     @api property = true;
 }
 `;
+const codeWithoutDefaultExportSingleClass = `
+import { api, LightningElement } from 'lwc';
+class Foo extends LightningElement {
+    @api foo;
+}
+`;
+const codeWithoutDefaultExportMultipleClasses = `
+import { api, LightningElement } from 'lwc';
+class Foo extends LightningElement {
+    @api foo;
+}
+class Bar extends LightningElement {
+    @api bar;
+}
+`;
 
 it('can get metadata from a simple component', async () => {
     await compileSource(codeOk, 'foo.js');
@@ -44,6 +59,21 @@ it('displays an error for a component with syntax error', async () => {
     expect(result.diagnostics).toHaveLength(1);
     const [diagnostic] = result.diagnostics;
     expect(diagnostic.message).toMatch('Unexpected token (4:17)');
+});
+
+it('returns empty metadata for a script without a clear main component class', async () => {
+    const result = await compileSource(codeWithoutDefaultExportMultipleClasses, 'foo.js');
+    expect(result.metadata?.decorators).toHaveLength(0);
+    expect(result.metadata?.classMembers).toHaveLength(0);
+    expect(result.metadata?.exports).toHaveLength(0);
+});
+
+it('returns metadata for a script with one component class, even when not exported', async () => {
+    const result = await compileSource(codeWithoutDefaultExportSingleClass, 'foo.js');
+    console.log(result);
+    expect(result.metadata?.decorators).toHaveLength(1);
+    expect(result.metadata?.classMembers).toHaveLength(1);
+    expect(result.metadata?.exports).toHaveLength(0);
 });
 
 it('displays an error for a component with other errors', async () => {

--- a/packages/lwc-language-server/src/javascript/type-mapping.ts
+++ b/packages/lwc-language-server/src/javascript/type-mapping.ts
@@ -541,9 +541,24 @@ function getExports(lwcExports: LwcExport[]): InternalModuleExports[] {
  * LWC language server to analyze code in a user's IDE.
  */
 export function mapLwcMetadataToInternal(lwcMeta: ScriptFile): InternalMetadata {
-    const mainClassObj = lwcMeta.classes.find(classObj => {
-        return classObj.id == lwcMeta.mainClass.refId;
-    });
+    let mainClassObj;
+    if (lwcMeta.mainClass) {
+        mainClassObj = lwcMeta.classes.find(classObj => {
+            return classObj.id == lwcMeta.mainClass.refId;
+        });
+    } else if (lwcMeta.classes.length === 1) {
+        mainClassObj = lwcMeta.classes[0];
+    }
+
+    // If we are unable to identify the main class object from the provided metadata,
+    // it will not be possible calculate decorators, members, etc.
+    if (!mainClassObj) {
+        return {
+            decorators: [],
+            classMembers: [],
+            exports: [],
+        };
+    }
 
     const defaultExport = lwcMeta.exports.filter((exp) => exp.defaultExport)[0];
     const declarationLoc = externalToInternalLoc(defaultExport?.location ?? mainClassObj.location);


### PR DESCRIPTION
### What does this PR do?

In cases where the main class of a JavaScript file could not be identified, an error was thrown during analysis of the associated metadata. This would cause the language server to crash in VSCode. 👎 

This PR fixes the issue, providing metadata is there is an exported class or if only a single class is defined in the `.js` file. If multiple classes are defined and none of them are default exports, the language server will now return no data. No code hints will be provided, but the language server will not crash.

### What issues does this PR fix or reference?

Fixes forcedotcom/salesforcedx-vscode#4994.
