### PR TITLE
Make lwc & aura language server available to be run from an executable file

### DIFF
--- a/packages/aura-language-server/bin/aura-language-server.js
+++ b/packages/aura-language-server/bin/aura-language-server.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../lib/server.js');

--- a/packages/aura-language-server/package.json
+++ b/packages/aura-language-server/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/forcedotcom/lightning-language-server.git"
   },
+  "bin": {
+    "aura-language-server": "bin/aura-language-server.js"
+  },
   "scripts": {
     "clean": "rm -rf lib",
     "cleanTestData": "node ../../scripts/removeTestData.js",

--- a/packages/lwc-language-server/bin/lwc-language-server.js
+++ b/packages/lwc-language-server/bin/lwc-language-server.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../lib/server.js');

--- a/packages/lwc-language-server/package.json
+++ b/packages/lwc-language-server/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/forcedotcom/lightning-language-server.git"
   },
+  "bin": {
+    "lwc-language-server": "./bin/lwc-language-server.js"
+  },
   "scripts": {
     "clean": "rm -rf lib && rm -rf src/resources/sfdx/typings/copied",
     "cleanTestData": "node ../../scripts/removeTestData.js",


### PR DESCRIPTION
### What does this PR do?
This PR creates executable files and defines the bin property in package.json for both lwc language server and aura language server.

#581 

### What issues does this PR fix or reference?
This allows the language servers to be run using a terminal command, which in return allows editors like neovim to integrate with language servers using `stdio`. [Neovim LSP DOC](https://neovim.io/doc/user/lsp.html#vim.lsp.start())
