### PR TITLE
fix: update metadata mapping to handle no getter

### DIFF
--- a/packages/lwc-language-server/src/javascript/__tests__/fixtures/nogetter.js
+++ b/packages/lwc-language-server/src/javascript/__tests__/fixtures/nogetter.js
@@ -1,0 +1,8 @@
+import { LightningElement } from 'lwc';
+/** NoGetter doc */
+export default class NoGetter extends LightningElement {
+    _property = '';
+    set property(value) {
+        this._property = value;
+    }
+}

--- a/packages/lwc-language-server/src/javascript/__tests__/type-mapping.test.ts
+++ b/packages/lwc-language-server/src/javascript/__tests__/type-mapping.test.ts
@@ -36,3 +36,34 @@ it('can map new metadata to old metadata', async () => {
 
     expect(derivedMetadata).toEqual(oldMetadata);
 });
+
+it('Should handle mapping when there is a property with only a setter', async () => {
+    const filepath = path.join('src', 'javascript', '__tests__', 'fixtures', 'nogetter.js');
+    const content = fs.readFileSync(filepath, 'utf8');
+
+    const newMetadataOpts: BundleConfig = {
+        type: 'internal',
+        name: 'nogetter',
+        namespace: 'x',
+        namespaceMapping: {},
+        files: [
+            {
+                fileName: 'nogetter.js',
+                source: content,
+            },
+        ],
+    };
+
+    const modernMetadata = collectBundleMetadata(newMetadataOpts);
+    const derivedMetadata = mapLwcMetadataToInternal(modernMetadata.files[0] as ScriptFile);
+
+    const oldTransformOpts: OldCompilerOptions = {
+        name: 'metadata',
+        namespace: 'x',
+        files: {},
+    };
+    const transformerResult = await transform(content, 'nogetter.js', oldTransformOpts);
+    const oldMetadata: Metadata = transformerResult.metadata as Metadata;
+
+    expect(derivedMetadata).toEqual(oldMetadata);
+});

--- a/packages/lwc-language-server/src/javascript/type-mapping.ts
+++ b/packages/lwc-language-server/src/javascript/type-mapping.ts
@@ -217,17 +217,25 @@ function getMemberProperty(propertyObj: ClassProperty): InternalClassMember | nu
         propertyObj.dataProperty,
     );
 
+    // Note there can only be a getter or only a setter, both are not required.
+    // Use the getter if available, or the setter if there is no getter.  
+    let loc: SourceLocation;
+    if (propertyObj.propertyType === 'accessor') {
+        if (propertyObj.getter) {
+            loc = propertyObj.getter.location
+        } else if (propertyObj.setter) {
+            loc = propertyObj.setter.location
+        }
+     } else {
+        loc = propertyObj?.dataProperty.location
+    }
     return stripKeysWithUndefinedVals({
         name: propertyObj.name,
         type: 'property',
         value,
         decorator: decoratorType,
         doc: propertyObj.__internal__doc,
-        loc: externalToInternalLoc(
-            propertyObj.propertyType === 'accessor'
-                ? propertyObj.getter.location
-                : propertyObj.dataProperty.location
-        ),
+        loc: externalToInternalLoc(loc),
     });
 }
 


### PR DESCRIPTION
### What does this PR do?
Update the javascript type mapping to handle the case where a class has a property with only a setter.

### What issues does this PR fix or reference?
@W-14391061@
https://github.com/forcedotcom/salesforcedx-vscode/issues/5069