### PR TITLE
fix: do not write jsconfig.json on core when there is tsconfig.json

### DIFF
--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -281,20 +281,27 @@ it('configureCoreMulti()', async () => {
     const jsconfigPathGlobal = context.workspaceRoots[1] + '/modules/jsconfig.json';
     const codeWorkspacePath = CORE_ALL_ROOT + '/core.code-workspace';
     const launchPath = CORE_ALL_ROOT + '/.vscode/launch.json';
+    const tsconfigPathForce = context.workspaceRoots[0] + '/tsconfig.json';
 
     // make sure no generated files are there from previous runs
     fs.removeSync(jsconfigPathGlobal);
     fs.removeSync(jsconfigPathForce);
     fs.removeSync(codeWorkspacePath);
     fs.removeSync(launchPath);
+    fs.removeSync(tsconfigPathForce);
+
+    fs.createFileSync(tsconfigPathForce);
 
     // configure and verify typings/jsconfig after configuration:
     await context.configureProject();
 
     // verify newly created jsconfig.json
     verifyJsconfigCore(jsconfigPathGlobal);
-    verifyJsconfigCore(jsconfigPathForce);
+    // verify jsconfig.json is not created when there is a tsconfig.json
+    expect(fs.existsSync(tsconfigPathForce)).not.toExist();
     verifyTypingsCore();
+
+    fs.removeSync(tsconfigPathForce);
 });
 
 it('configureCoreAll()', async () => {

--- a/packages/lightning-lsp-common/src/context.ts
+++ b/packages/lightning-lsp-common/src/context.ts
@@ -396,6 +396,15 @@ export class WorkspaceContext {
     }
 
     /**
+     * @param modulesDir
+     * @returns whether a tsconfig.json file exists in the same directory of modulesDir
+     */
+    private hasTSConfigOnCore(modulesDir: string): boolean {
+        const tsConfigFile = path.join(modulesDir, '..', 'tsconfig.json');
+        return fs.pathExistsSync(tsConfigFile);
+    }
+
+    /**
      * Writes to and updates Jsconfig files and ES Lint files of WorkspaceRoots, optimizing by type
      */
     private async writeJsconfigJson(): Promise<void> {
@@ -419,16 +428,22 @@ export class WorkspaceContext {
                 jsConfigTemplate = await fs.readFile(utils.getCoreResource('jsconfig-core.json'), 'utf8');
                 jsConfigContent = this.processTemplate(jsConfigTemplate, { project_root: '../..' });
                 for (const modulesDir of modulesDirs) {
-                    const jsConfigPath = path.join(modulesDir, 'jsconfig.json');
-                    this.updateConfigFile(jsConfigPath, jsConfigContent);
+                    // only writes jsconfig.json if there is no tsconfig.json on core
+                    if (!this.hasTSConfigOnCore(modulesDir)) {
+                        const jsConfigPath = path.join(modulesDir, 'jsconfig.json');
+                        this.updateConfigFile(jsConfigPath, jsConfigContent);
+                    }
                 }
                 break;
             case WorkspaceType.CORE_PARTIAL:
                 jsConfigTemplate = await fs.readFile(utils.getCoreResource('jsconfig-core.json'), 'utf8');
                 jsConfigContent = this.processTemplate(jsConfigTemplate, { project_root: '../..' });
                 for (const modulesDir of modulesDirs) {
-                    const jsConfigPath = path.join(modulesDir, 'jsconfig.json');
-                    this.updateConfigFile(jsConfigPath, jsConfigContent); // no workspace reference yet, that comes in update config file
+                    // only writes jsconfig.json if there is no tsconfig.json on core
+                    if (!this.hasTSConfigOnCore(modulesDir)) {
+                        const jsConfigPath = path.join(modulesDir, 'jsconfig.json');
+                        this.updateConfigFile(jsConfigPath, jsConfigContent); // no workspace reference yet, that comes in update config file
+                    }
                 }
                 break;
         }


### PR DESCRIPTION
### What does this PR do?
Since we started to support TypeScript for LWC on core, we added `tsconfig.json` files on core's UI modules directory, e.g., `ui-force-components/tsconfig.json`. This `tsconfig.json` would conflict with `jsconfig.json` file that is automatically generated. This PR disable the generation of `jsconfig.json` file on core if there is an existing `jsconfig.json` file on core.

### What issues does this PR fix or reference?
@W-14590716@

### Functionality before
https://github.com/forcedotcom/lightning-language-server/assets/113132642/b6c4cd88-08fa-41ae-97ec-8577709598b8

### Functionality after
https://github.com/forcedotcom/lightning-language-server/assets/113132642/89fae34f-c8db-42a4-a1f1-864d75bf040f