### PR TITLE
feat: automatically updating `tsconfig.json`'s `paths` mapping for core workspaces.

### DIFF
--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -154,6 +154,26 @@ it('isLWCJavascript()', async () => {
     expect(await context.isLWCJavascript(document)).toBeTruthy();
 });
 
+it('isLWCTypeScript()', async () => {
+    const context = new WorkspaceContext(CORE_PROJECT_ROOT);
+
+    // lwc .ts
+    let document = readAsTextDocument(CORE_PROJECT_ROOT + '/modules/one/app-nav-bar/app-nav-bar.ts');
+    expect(await context.isLWCTypeScript(document)).toBeTruthy();
+
+    // lwc .ts outside namespace root
+    document = readAsTextDocument(CORE_ALL_ROOT + '/ui-force-components/modules/force/input-phone/input-phone.ts');
+    expect(await context.isLWCTypeScript(document)).toBeFalsy();
+
+    // lwc .html
+    document = readAsTextDocument(CORE_PROJECT_ROOT + '/modules/one/app-nav-bar/app-nav-bar.html');
+    expect(await context.isLWCTypeScript(document)).toBeFalsy();
+
+    // lwc .js
+    document = readAsTextDocument(CORE_PROJECT_ROOT + '/modules/one/app-nav-bar/app-nav-bar.js');
+    expect(await context.isLWCTypeScript(document)).toBeFalsy();
+});
+
 it('configureSfdxProject()', async () => {
     const context = new WorkspaceContext('test-workspaces/sfdx-workspace');
     const jsconfigPathForceApp = FORCE_APP_ROOT + '/lwc/jsconfig.json';

--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -318,7 +318,7 @@ it('configureCoreMulti()', async () => {
     // verify newly created jsconfig.json
     verifyJsconfigCore(jsconfigPathGlobal);
     // verify jsconfig.json is not created when there is a tsconfig.json
-    expect(fs.existsSync(tsconfigPathForce)).not.toExist();
+    expect(fs.existsSync(jsconfigPathForce)).not.toExist();
     verifyTypingsCore();
 
     fs.removeSync(tsconfigPathForce);

--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -155,13 +155,14 @@ it('isLWCJavascript()', async () => {
 });
 
 it('isLWCTypeScript()', async () => {
+    // workspace root project is ui-global-components
     const context = new WorkspaceContext(CORE_PROJECT_ROOT);
 
     // lwc .ts
     let document = readAsTextDocument(CORE_PROJECT_ROOT + '/modules/one/app-nav-bar/app-nav-bar.ts');
     expect(await context.isLWCTypeScript(document)).toBeTruthy();
 
-    // lwc .ts outside namespace root
+    // lwc .ts outside workspace root in ui-force-components
     document = readAsTextDocument(CORE_ALL_ROOT + '/ui-force-components/modules/force/input-phone/input-phone.ts');
     expect(await context.isLWCTypeScript(document)).toBeFalsy();
 

--- a/packages/lightning-lsp-common/src/__tests__/test-utils.ts
+++ b/packages/lightning-lsp-common/src/__tests__/test-utils.ts
@@ -19,6 +19,8 @@ function languageId(path: string): string {
     switch (suffix.substring(1)) {
         case 'js':
             return 'javascript';
+        case 'ts':
+            return 'typescript';
         case 'html':
             return 'html';
         case 'app':

--- a/packages/lightning-lsp-common/src/context.ts
+++ b/packages/lightning-lsp-common/src/context.ts
@@ -80,8 +80,9 @@ async function findNamespaceRoots(root: string, maxDepth = 5): Promise<{ lwc: st
         for (const subdir of subdirs) {
             // Is a root if any subdir matches a name/name.js with name.js being a module
             const basename = path.basename(subdir);
-            const modulePath = path.join(subdir, basename + '.js');
-            if (fs.existsSync(modulePath)) {
+            const modulePathJs = path.join(subdir, basename + '.js');
+            const modulePathTs = path.join(subdir, basename + '.ts');
+            if (fs.existsSync(modulePathJs) || fs.existsSync(modulePathTs)) {
                 // TODO: check contents for: from 'lwc'?
                 return true;
             }
@@ -305,6 +306,11 @@ export class WorkspaceContext {
         await this.writeJsconfigJson();
         await this.writeSettings();
         await this.writeTypings();
+
+        const modules = await this.findAllModules();
+        for (const ns in modules) {
+            console.log(ns);
+        }
     }
 
     /**
@@ -446,6 +452,15 @@ export class WorkspaceContext {
                     }
                 }
                 break;
+        }
+    }
+
+    private async updateTsConfigOnCore(): Promise<void> {
+        if (this.type === WorkspaceType.CORE_ALL || this.type === WorkspaceType.CORE_PARTIAL) {
+            const modulesDirs = await this.getModulesDirs();
+            for (const modulesDir of modulesDirs) {
+                console.log(modulesDir);
+            }
         }
     }
 

--- a/packages/lightning-lsp-common/src/context.ts
+++ b/packages/lightning-lsp-common/src/context.ts
@@ -54,21 +54,6 @@ async function findModulesIn(namespaceRoot: string): Promise<string[]> {
     return files;
 }
 
-async function generateLWCMappings(namespaceRoot: string): Promise<Record<string, string[]>> {
-    const componentMappings: Record<string, string[]> = {};
-    const subdirs = await findSubdirectories(namespaceRoot);
-    const namespace = path.basename(namespaceRoot);
-    for (const subdir of subdirs) {
-        const componentName = path.basename(subdir);
-        const componentPath = path.join(subdir, componentName + '.ts');
-        if (await fs.pathExists(componentPath)) {
-            const componentFullName = `${namespace}/${componentName}`;
-            componentMappings[componentFullName] = [`./modules/${namespace}/${componentName}/${componentName}`];
-        }
-    }
-    return componentMappings;
-}
-
 async function readSfdxProjectConfig(root: string): Promise<SfdxProjectConfig> {
     try {
         return JSON.parse(await fs.readFile(getSfdxProjectFile(root), 'utf8'));
@@ -273,6 +258,14 @@ export class WorkspaceContext {
         return document.languageId === 'javascript' && (await this.isInsideModulesRoots(document));
     }
 
+    public async isLWCTypeScript(document: TextDocument): Promise<boolean> {
+        return (
+            (this.type === WorkspaceType.CORE_ALL || this.type === WorkspaceType.CORE_PARTIAL) &&
+            document.languageId === 'typescript' &&
+            (await this.isInsideModulesRoots(document))
+        );
+    }
+
     public async isInsideAuraRoots(document: TextDocument): Promise<boolean> {
         const file = utils.toResolvedPath(document.uri);
         for (const ws of this.workspaceRoots) {
@@ -321,7 +314,6 @@ export class WorkspaceContext {
         await this.writeJsconfigJson();
         await this.writeSettings();
         await this.writeTypings();
-        await this.updateTsConfigOnCore();
     }
 
     /**
@@ -463,37 +455,6 @@ export class WorkspaceContext {
                     }
                 }
                 break;
-        }
-    }
-
-    private async updateTsConfigOnCore(): Promise<void> {
-        if (this.type === WorkspaceType.CORE_ALL || this.type === WorkspaceType.CORE_PARTIAL) {
-            const namespaceRoots = await this.findNamespaceRootsUsingTypeCache();
-            for (const namespaceRoot of namespaceRoots.lwc) {
-                const tsConfigFile = path.join(namespaceRoot, '..', '..', 'tsconfig.json');
-                if (await fs.pathExists(tsConfigFile)) {
-                    const mapping = await generateLWCMappings(namespaceRoot);
-                    if (Object.keys(mapping).length > 0) {
-                        try {
-                            const tsconfigString = await fs.readFile(tsConfigFile, 'utf8');
-                            // remove any trailing commas
-                            const tsconfig = JSON.parse(tsconfigString.replace(/,([ |\t|\n]+[\}|\]|\)])/g, '$1'));
-                            if (tsconfig?.compilerOptions?.paths) {
-                                Object.assign(tsconfig.compilerOptions.paths, mapping);
-                                const sortedKeys = Object.keys(tsconfig.compilerOptions.paths).sort();
-                                const sortedPaths: Record<string, string[]> = {};
-                                sortedKeys.forEach(key => {
-                                    sortedPaths[key] = tsconfig.compilerOptions.paths[key];
-                                });
-                                tsconfig.compilerOptions.paths = sortedPaths;
-                                utils.writeJsonSync(tsConfigFile, tsconfig);
-                            }
-                        } catch (error) {
-                            console.warn(`Error updating core tsconfig. Continuing, but may be missing some config. ${error}`);
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/packages/lwc-language-server/src/__tests__/test-utils.ts
+++ b/packages/lwc-language-server/src/__tests__/test-utils.ts
@@ -18,6 +18,8 @@ function languageId(path: string): string {
     switch (suffix.substring(1)) {
         case 'js':
             return 'javascript';
+        case 'ts':
+            return 'typescript';
         case 'html':
             return 'html';
         case 'app':

--- a/packages/lwc-language-server/src/__tests__/typescript.test.ts
+++ b/packages/lwc-language-server/src/__tests__/typescript.test.ts
@@ -1,0 +1,101 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { shared } from '@salesforce/lightning-lsp-common';
+import TSConfigPathIndexer from '../typescript/tsconfig-path-indexer';
+
+const { WorkspaceType } = shared;
+const TEST_WORKSPACE_PARENT_DIR = path.resolve('../..');
+const CORE_ROOT = path.join(TEST_WORKSPACE_PARENT_DIR, 'test-workspaces', 'core-like-workspace', 'coreTS', 'core');
+
+const tsConfigForce = path.join(CORE_ROOT, 'ui-force-components', 'tsconfig.json');
+const tsConfigGlobal = path.join(CORE_ROOT, 'ui-global-components', 'tsconfig.json');
+
+function readTSConfigFile(tsconfigPath: string): object {
+    if (!fs.pathExistsSync(tsconfigPath)) {
+        return null;
+    }
+    return JSON.parse(fs.readFileSync(tsconfigPath, 'utf8'));
+}
+
+function restoreTSConfigFiles(): void {
+    const tsconfig = {
+        extends: '../tsconfig.json',
+        compilerOptions: {
+            paths: {},
+        },
+    };
+    const tsconfigPaths = [tsConfigForce, tsConfigGlobal];
+    for (const tsconfigPath of tsconfigPaths) {
+        fs.writeJSONSync(tsconfigPath, tsconfig, {
+            spaces: 4,
+        });
+    }
+}
+
+beforeEach(async () => {
+    restoreTSConfigFiles();
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    restoreTSConfigFiles();
+});
+
+describe('ComponentIndexer', () => {
+    describe('new', () => {
+        it('initializes with the root of a core root dir', () => {
+            const expectedPath: string = path.resolve('../../test-workspaces/core-like-workspace/coreTS/core');
+            const tsconfigPathIndexer = new TSConfigPathIndexer([CORE_ROOT]);
+            expect(tsconfigPathIndexer.coreModulesWithTSConfig.length).toEqual(2);
+            expect(tsconfigPathIndexer.coreModulesWithTSConfig[0]).toEqual(path.join(expectedPath, 'ui-force-components'));
+            expect(tsconfigPathIndexer.coreModulesWithTSConfig[1]).toEqual(path.join(expectedPath, 'ui-global-components'));
+            expect(tsconfigPathIndexer.workspaceType).toEqual(WorkspaceType.CORE_ALL);
+            expect(tsconfigPathIndexer.coreRoot).toEqual(expectedPath);
+        });
+
+        it('initializes with the root of a core project dir', () => {
+            const expectedPath: string = path.resolve('../../test-workspaces/core-like-workspace/coreTS/core');
+            const tsconfigPathIndexer = new TSConfigPathIndexer([path.join(CORE_ROOT, 'ui-force-components')]);
+            expect(tsconfigPathIndexer.coreModulesWithTSConfig.length).toEqual(1);
+            expect(tsconfigPathIndexer.coreModulesWithTSConfig[0]).toEqual(path.join(expectedPath, 'ui-force-components'));
+            expect(tsconfigPathIndexer.workspaceType).toEqual(WorkspaceType.CORE_PARTIAL);
+            expect(tsconfigPathIndexer.coreRoot).toEqual(expectedPath);
+        });
+    });
+
+    describe('instance methods', () => {
+        describe('#init', () => {
+            it('no-op on sfdx workspace root', async () => {
+                const tsconfigPathIndexer = new TSConfigPathIndexer([path.join(TEST_WORKSPACE_PARENT_DIR, 'test-workspaces', 'sfdx-workspace')]);
+                const spy = jest.spyOn(tsconfigPathIndexer, 'componentEntries', 'get');
+                await tsconfigPathIndexer.init();
+                expect(spy).not.toHaveBeenCalled();
+                expect(tsconfigPathIndexer.coreRoot).toBeUndefined();
+            });
+
+            it('generates paths mappings for all modules on core', async () => {
+                const tsconfigPathIndexer = new TSConfigPathIndexer([CORE_ROOT]);
+                await tsconfigPathIndexer.init();
+                const tsConfigForceObj = readTSConfigFile(tsConfigForce);
+                expect(tsConfigForceObj).toEqual({
+                    extends: '../tsconfig.json',
+                    compilerOptions: {
+                        paths: {
+                            'clients/context-library-lwc': ['./modules/clients/context-library-lwc/context-library-lwc'],
+                            'force/input-phone': ['./modules/force/input-phone/input-phone'],
+                        },
+                    },
+                });
+                const tsConfigGlobalObj = readTSConfigFile(tsConfigGlobal);
+                expect(tsConfigGlobalObj).toEqual({
+                    extends: '../tsconfig.json',
+                    compilerOptions: {
+                        paths: {
+                            'one/app-nav-bar': ['./modules/one/app-nav-bar/app-nav-bar'],
+                        },
+                    },
+                });
+            });
+        });
+    });
+});

--- a/packages/lwc-language-server/src/__tests__/typescript.test.ts
+++ b/packages/lwc-language-server/src/__tests__/typescript.test.ts
@@ -5,14 +5,13 @@ import { readAsTextDocument } from './test-utils';
 import TSConfigPathIndexer from '../typescript/tsconfig-path-indexer';
 import { collectImportsForDocument } from '../typescript/imports';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { file } from 'babel-types';
 
 const { WorkspaceType } = shared;
 const TEST_WORKSPACE_PARENT_DIR = path.resolve('../..');
-const CORE_ROOT = path.join(TEST_WORKSPACE_PARENT_DIR, 'test-workspaces', 'core-like-workspace', 'coreTS', 'core');
+const CORE_ROOT = path.resolve(TEST_WORKSPACE_PARENT_DIR, 'test-workspaces', 'core-like-workspace', 'coreTS', 'core');
 
-const tsConfigForce = path.join(CORE_ROOT, 'ui-force-components', 'tsconfig.json');
-const tsConfigGlobal = path.join(CORE_ROOT, 'ui-global-components', 'tsconfig.json');
+const tsConfigForce = path.resolve(CORE_ROOT, 'ui-force-components', 'tsconfig.json');
+const tsConfigGlobal = path.resolve(CORE_ROOT, 'ui-global-components', 'tsconfig.json');
 
 function readTSConfigFile(tsconfigPath: string): object {
     if (!fs.pathExistsSync(tsconfigPath)) {
@@ -55,17 +54,17 @@ describe('TSConfigPathIndexer', () => {
             const expectedPath: string = path.resolve('../../test-workspaces/core-like-workspace/coreTS/core');
             const tsconfigPathIndexer = new TSConfigPathIndexer([CORE_ROOT]);
             expect(tsconfigPathIndexer.coreModulesWithTSConfig.length).toEqual(2);
-            expect(tsconfigPathIndexer.coreModulesWithTSConfig[0]).toEqual(path.join(expectedPath, 'ui-force-components'));
-            expect(tsconfigPathIndexer.coreModulesWithTSConfig[1]).toEqual(path.join(expectedPath, 'ui-global-components'));
+            expect(tsconfigPathIndexer.coreModulesWithTSConfig[0]).toEqual(path.resolve(expectedPath, 'ui-force-components'));
+            expect(tsconfigPathIndexer.coreModulesWithTSConfig[1]).toEqual(path.resolve(expectedPath, 'ui-global-components'));
             expect(tsconfigPathIndexer.workspaceType).toEqual(WorkspaceType.CORE_ALL);
             expect(tsconfigPathIndexer.coreRoot).toEqual(expectedPath);
         });
 
         it('initializes with the root of a core project dir', () => {
             const expectedPath: string = path.resolve('../../test-workspaces/core-like-workspace/coreTS/core');
-            const tsconfigPathIndexer = new TSConfigPathIndexer([path.join(CORE_ROOT, 'ui-force-components')]);
+            const tsconfigPathIndexer = new TSConfigPathIndexer([path.resolve(CORE_ROOT, 'ui-force-components')]);
             expect(tsconfigPathIndexer.coreModulesWithTSConfig.length).toEqual(1);
-            expect(tsconfigPathIndexer.coreModulesWithTSConfig[0]).toEqual(path.join(expectedPath, 'ui-force-components'));
+            expect(tsconfigPathIndexer.coreModulesWithTSConfig[0]).toEqual(path.resolve(expectedPath, 'ui-force-components'));
             expect(tsconfigPathIndexer.workspaceType).toEqual(WorkspaceType.CORE_PARTIAL);
             expect(tsconfigPathIndexer.coreRoot).toEqual(expectedPath);
         });
@@ -74,7 +73,7 @@ describe('TSConfigPathIndexer', () => {
     describe('instance methods', () => {
         describe('init', () => {
             it('no-op on sfdx workspace root', async () => {
-                const tsconfigPathIndexer = new TSConfigPathIndexer([path.join(TEST_WORKSPACE_PARENT_DIR, 'test-workspaces', 'sfdx-workspace')]);
+                const tsconfigPathIndexer = new TSConfigPathIndexer([path.resolve(TEST_WORKSPACE_PARENT_DIR, 'test-workspaces', 'sfdx-workspace')]);
                 const spy = jest.spyOn(tsconfigPathIndexer, 'componentEntries', 'get');
                 await tsconfigPathIndexer.init();
                 expect(spy).not.toHaveBeenCalled();
@@ -189,9 +188,9 @@ describe('TSConfigPathIndexer', () => {
 
         describe('updateTSConfigFileForDocument', () => {
             it('no-op on sfdx workspace root', async () => {
-                const tsconfigPathIndexer = new TSConfigPathIndexer([path.join(TEST_WORKSPACE_PARENT_DIR, 'test-workspaces', 'sfdx-workspace')]);
+                const tsconfigPathIndexer = new TSConfigPathIndexer([path.resolve(TEST_WORKSPACE_PARENT_DIR, 'test-workspaces', 'sfdx-workspace')]);
                 await tsconfigPathIndexer.init();
-                const filePath = path.join(CORE_ROOT, 'ui-force-components', 'modules', 'force', 'input-phone', 'input-phone.ts');
+                const filePath = path.resolve(CORE_ROOT, 'ui-force-components', 'modules', 'force', 'input-phone', 'input-phone.ts');
                 const spy = jest.spyOn(tsconfigPathIndexer as any, 'addNewPathMapping');
                 await tsconfigPathIndexer.updateTSConfigFileForDocument(readAsTextDocument(filePath));
                 expect(spy).not.toHaveBeenCalled();
@@ -201,7 +200,7 @@ describe('TSConfigPathIndexer', () => {
             it('updates tsconfig for all imports', async () => {
                 const tsconfigPathIndexer = new TSConfigPathIndexer([CORE_ROOT]);
                 await tsconfigPathIndexer.init();
-                const filePath = path.join(CORE_ROOT, 'ui-force-components', 'modules', 'force', 'input-phone', 'input-phone.ts');
+                const filePath = path.resolve(CORE_ROOT, 'ui-force-components', 'modules', 'force', 'input-phone', 'input-phone.ts');
                 await tsconfigPathIndexer.updateTSConfigFileForDocument(readAsTextDocument(filePath));
                 const tsConfigForceObj = readTSConfigFile(tsConfigForce);
                 expect(tsConfigForceObj).toEqual({
@@ -222,7 +221,7 @@ describe('TSConfigPathIndexer', () => {
                 const fileContent = `
                     import { util } from 'ns/notFound';
                 `;
-                const filePath = path.join(CORE_ROOT, 'ui-force-components', 'modules', 'force', 'input-phone', 'input-phone.ts');
+                const filePath = path.resolve(CORE_ROOT, 'ui-force-components', 'modules', 'force', 'input-phone', 'input-phone.ts');
                 await tsconfigPathIndexer.updateTSConfigFileForDocument(createTextDocumentFromString(fileContent, filePath));
                 const tsConfigForceObj = readTSConfigFile(tsConfigForce);
                 expect(tsConfigForceObj).toEqual({

--- a/packages/lwc-language-server/src/__tests__/typescript.test.ts
+++ b/packages/lwc-language-server/src/__tests__/typescript.test.ts
@@ -44,7 +44,7 @@ afterEach(() => {
     restoreTSConfigFiles();
 });
 
-describe('ComponentIndexer', () => {
+describe('TSConfigPathIndexer', () => {
     describe('new', () => {
         it('initializes with the root of a core root dir', () => {
             const expectedPath: string = path.resolve('../../test-workspaces/core-like-workspace/coreTS/core');
@@ -95,6 +95,32 @@ describe('ComponentIndexer', () => {
                     compilerOptions: {
                         paths: {
                             'one/app-nav-bar': ['./modules/one/app-nav-bar/app-nav-bar'],
+                        },
+                    },
+                });
+            });
+
+            it('removes paths mapping for deleted module on core', async () => {
+                const oldTSConfig = {
+                    extends: '../tsconfig.json',
+                    compilerOptions: {
+                        paths: {
+                            'force/deleted': './modules/force/deleted/deleted',
+                        },
+                    },
+                };
+                fs.writeJSONSync(tsConfigForce, oldTSConfig, {
+                    spaces: 4,
+                });
+                const tsconfigPathIndexer = new TSConfigPathIndexer([CORE_ROOT]);
+                await tsconfigPathIndexer.init();
+                const tsConfigForceObj = readTSConfigFile(tsConfigForce);
+                expect(tsConfigForceObj).toEqual({
+                    extends: '../tsconfig.json',
+                    compilerOptions: {
+                        paths: {
+                            'clients/context-library-lwc': ['./modules/clients/context-library-lwc/context-library-lwc'],
+                            'force/input-phone': ['./modules/force/input-phone/input-phone'],
                         },
                     },
                 });

--- a/packages/lwc-language-server/src/lwc-server.ts
+++ b/packages/lwc-language-server/src/lwc-server.ts
@@ -274,7 +274,7 @@ export default class Server {
             }
         } else if (await this.context.isLWCTypeScript(document)) {
             // update tsconfig.json file paths when a TS file is saved
-            this.tsconfigPathIndexer.updateTSConfigFileForDocument(document);
+            await this.tsconfigPathIndexer.updateTSConfigFileForDocument(document);
         }
     }
 

--- a/packages/lwc-language-server/src/lwc-server.ts
+++ b/packages/lwc-language-server/src/lwc-server.ts
@@ -33,6 +33,7 @@ import ComponentIndexer from './component-indexer';
 import TypingIndexer from './typing-indexer';
 import templateLinter from './template/linter';
 import Tag from './tag';
+import TSConfigPathIndexer from './typescript/tsconfig-path-indexer';
 import { URI } from 'vscode-uri';
 
 export const propertyRegex = new RegExp(/\{(?<property>\w+)\.*.*\}/);
@@ -77,6 +78,7 @@ export default class Server {
     languageService: LanguageService;
     auraDataProvider: AuraDataProvider;
     lwcDataProvider: LWCDataProvider;
+    tsconfigPathIndexer: TSConfigPathIndexer;
 
     constructor() {
         this.connection.onInitialize(this.onInitialize.bind(this));
@@ -99,6 +101,8 @@ export default class Server {
         this.lwcDataProvider = new LWCDataProvider({ indexer: this.componentIndexer });
         this.auraDataProvider = new AuraDataProvider({ indexer: this.componentIndexer });
         this.typingIndexer = new TypingIndexer({ workspaceRoot: this.workspaceRoots[0] });
+        // For maintaining tsconfig.json file paths on core workspace
+        this.tsconfigPathIndexer = new TSConfigPathIndexer(this.workspaceRoots);
         this.languageService = getLanguageService({
             customDataProviders: [this.lwcDataProvider, this.auraDataProvider],
             useDefaultDataProvider: false,
@@ -107,6 +111,7 @@ export default class Server {
         await this.context.configureProject();
         await this.componentIndexer.init();
         this.typingIndexer.init();
+        await this.tsconfigPathIndexer.init();
 
         return this.capabilities;
     }
@@ -267,6 +272,9 @@ export default class Server {
                     tag.updateMetadata(metadata);
                 }
             }
+        } else if (await this.context.isLWCTypeScript(document)) {
+            // update tsconfig.json file paths when a TS file is saved
+            this.tsconfigPathIndexer.updateTSConfigFileForDocument(document);
         }
     }
 

--- a/packages/lwc-language-server/src/typescript/imports.ts
+++ b/packages/lwc-language-server/src/typescript/imports.ts
@@ -1,0 +1,70 @@
+import * as ts from 'typescript';
+import { TextDocument } from 'vscode-languageserver';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
+
+/**
+ * Exclude some special importees that we don't need to analyze.
+ * The importees that are not needed include the following.
+ * 'lwc', 'lightning/*', '@salesforce/*', './', '../', '*.html', '*.css'.
+ * @param moduleSpecifier name of the importee.
+ * @returns true if the importee should be included for analyzing.
+ */
+function shouldIncludeImports(moduleSpecifier: string): boolean {
+    // excludes a few special imports
+    const exclusions = ['lightning/', '@salesforce/', './', '../'];
+    for (const exclusion of exclusions) {
+        if (moduleSpecifier.startsWith(exclusion)) {
+            return false;
+        }
+    }
+    // exclude html, css imports, and lwc imports
+    return !moduleSpecifier.endsWith('.html') && !moduleSpecifier.endsWith('.css') && moduleSpecifier !== 'lwc';
+}
+
+/**
+ * Adds an importee specifier to a set of importees.
+ */
+function addImports(imports: Set<string>, importText: string): void {
+    if (importText && shouldIncludeImports(importText)) {
+        imports.add(importText);
+    }
+}
+
+/**
+ * Parse a typescript file and collects all importees that we need to analyze.
+ * @param src ts source file
+ * @returns a set of strings containing the importees
+ */
+export function collectImports(src: ts.SourceFile): Set<string> {
+    const imports = new Set<string>();
+    const walk = (node: ts.Node): void => {
+        if (ts.isImportDeclaration(node)) {
+            // ES2015 import
+            const moduleSpecifier = node.moduleSpecifier as ts.StringLiteral;
+            addImports(imports, moduleSpecifier.text);
+        } else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+            // Dynamic import()
+            const moduleSpecifier = node.arguments[0];
+            if (ts.isStringLiteral(moduleSpecifier)) {
+                addImports(imports, moduleSpecifier.text);
+            }
+        }
+        ts.forEachChild(node, walk);
+    };
+    walk(src);
+    return imports;
+}
+
+/**
+ * Collect a set of importees for a TypeScript document.
+ * @param document a TypeScript document
+ * @returns a set of strings containing the importees
+ */
+export async function collectImportsForDocument(document: TextDocument): Promise<Set<string>> {
+    const filePath = URI.file(document.uri).fsPath;
+    const content = document.getText();
+    const fileName = path.parse(filePath).base;
+    const srcFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.ESNext);
+    return collectImports(srcFile);
+}

--- a/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
+++ b/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
@@ -111,7 +111,8 @@ export default class TSConfigPathIndexer {
         if (!this.isOnCore()) {
             return; // no-op if this is not a Core workspace
         }
-        const filePath = URI.file(document.uri).fsPath;
+        // replace Windows file separator
+        const filePath = path.normalize(URI.file(document.uri).fsPath).replace(/\\/g, '/');
         this.addNewPathMapping(filePath);
         const moduleName = this.getModuleName(filePath);
         const projectRoot = this.getProjectRoot(filePath);

--- a/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
+++ b/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
@@ -29,16 +29,16 @@ class TSConfigPathItem {
 }
 
 /**
- * An indexer that stores the TypeScript path mapping info on Core workspace.
+ * An indexer that stores the TypeScript path mapping info for the Core workspace.
  *
- * When using TypeScript for LWCs on core, tsconfig.json file's 'paths' attribute needs to be maintained so that
- * TypeScript compiler knows how to resolve imported LWC modules. This class maintains a mapping between LWCs
- * and their paths in tsconfig.json and automatically updates tsconfig.json file when initialized and when a LWC
- * TypeScript file is changed.
+ * When using TypeScript for LWCs in the core workspace, the tsconfig.json file's 'paths' attribute needs to be
+ * maintained to ensure that the TypeScript compiler can resolve imported LWC modules. This class serves to maintain
+ * a mapping between LWCs and their paths in tsconfig.json, automatically updating the file when initialized and
+ * whenever a LWC TypeScript file is changed.
  *
- * This includes a map for all TypeScript LWCs on core, the key is a component's full name (namespace/cmpName)
- * and the value is an object that contains info on how this component should be mapped to in tsconfig.json
- * so that TypeScript can find the component on the file system.
+ * This mapping encompasses all TypeScript LWCs in the core workspace. Each component's full name (namespace/cmpName)
+ * serves as the key, with the corresponding value being an object containing information on how the component should be
+ * mapped in tsconfig.json, thereby enabling TypeScript to locate the component within the file system.
  */
 export default class TSConfigPathIndexer {
     readonly coreModulesWithTSConfig: string[];

--- a/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
+++ b/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
@@ -97,8 +97,7 @@ export default class TSConfigPathIndexer {
         this.componentEntries.forEach(entry => {
             this.addNewPathMapping(entry);
         });
-        // update each project under the workspaceRoots
-
+        // update each project under the workspaceRoots that has a tsconfig.json
         for (const workspaceRoot of this.coreModulesWithTSConfig) {
             await this.updateTSConfigPaths(workspaceRoot);
         }
@@ -129,7 +128,7 @@ export default class TSConfigPathIndexer {
             }
         }
         const tsconfigFile = path.join(projectRoot, 'tsconfig.json');
-        this.updateTSConfigFile(tsconfigFile, mappings, false);
+        await this.updateTSConfigFile(tsconfigFile, mappings, false);
     }
 
     /**

--- a/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
+++ b/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
@@ -18,9 +18,9 @@ type TSConfigPathItemAttribute = {
 // An internal object representing a path mapping for tsconfig.json file on core
 class TSConfigPathItem {
     // internal typescript path mapping, e.g., "ui-force-components/modules/force/wireUtils/wireUtils"
-    public readonly tsPath: string;
+    readonly tsPath: string;
     // actual file path for the ts file
-    public readonly filePath: string;
+    readonly filePath: string;
 
     constructor(attribute: TSConfigPathItemAttribute) {
         this.tsPath = attribute.tsPath;

--- a/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
+++ b/packages/lwc-language-server/src/typescript/tsconfig-path-indexer.ts
@@ -1,0 +1,282 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { shared } from '@salesforce/lightning-lsp-common';
+import { sync } from 'fast-glob';
+import normalize from 'normalize-path';
+import { TextDocument } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
+import { collectImportsForDocument } from './imports';
+
+const { detectWorkspaceType, WorkspaceType } = shared;
+const REGEX_PATTERN = /\/core\/(.+?)\/modules\/(.+?)\/(.+?)\//;
+
+type TSConfigPathItemAttribute = {
+    readonly tsPath: string;
+    readonly filePath: string;
+};
+
+// An internal object representing a path mapping for tsconfig.json file on core
+class TSConfigPathItem {
+    // internal typescript path mapping, e.g., "ui-force-components/modules/force/wireUtils/wireUtils"
+    public readonly tsPath: string;
+    // actual file path for the ts file
+    public readonly filePath: string;
+
+    constructor(attribute: TSConfigPathItemAttribute) {
+        this.tsPath = attribute.tsPath;
+        this.filePath = attribute.filePath;
+    }
+}
+
+/**
+ * An indexer that stores the TypeScript path mapping info on Core workspace.
+ *
+ * When using TypeScript for LWCs on core, tsconfig.json file's 'paths' attribute needs to be maintained so that
+ * TypeScript compiler knows how to resolve imported LWC modules. This class maintains a mapping between LWCs
+ * and their paths in tsconfig.json and automatically updates tsconfig.json file when initialized and when a LWC
+ * TypeScript file is changed.
+ *
+ * This includes a map for all TypeScript LWCs on core, the key is a component's full name (namespace/cmpName)
+ * and the value is an object that contains info on how this component should be mapped to in tsconfig.json
+ * so that TypeScript can find the component on the file system.
+ */
+export default class TSConfigPathIndexer {
+    readonly workspaceRoots: string[];
+    readonly workspaceType: number;
+    // the root path for core directory
+    readonly coreRoot: string;
+    // A map for all TypeScript LWCs on core
+    pathMapping: Map<string, TSConfigPathItem> = new Map<string, TSConfigPathItem>();
+
+    constructor(workspaceRoots: string[]) {
+        this.workspaceRoots = workspaceRoots;
+        this.workspaceType = detectWorkspaceType(this.workspaceRoots);
+        switch (this.workspaceType) {
+            case WorkspaceType.CORE_ALL:
+                this.coreRoot = this.workspaceRoots[0];
+                break;
+            case WorkspaceType.CORE_PARTIAL:
+                this.coreRoot = path.join(this.workspaceRoots[0], '..');
+                break;
+        }
+    }
+
+    // gets all paths for TypeScript LWC components on core
+    get componentEntries(): string[] {
+        const defaultSource = normalize(`${this.coreRoot}/*/modules/*/*/*.ts`);
+        const files = sync(defaultSource);
+        return files.filter((item: string): boolean => {
+            const data = path.parse(item);
+            let cmpName = data.name;
+            // remove '.d' for any '.d.ts' files
+            if (cmpName.endsWith('.d')) {
+                cmpName = cmpName.replace('.d', '');
+            }
+            return data.dir.endsWith(cmpName);
+        });
+    }
+
+    // Initialization: build the path mapping for Core workspace.
+    public async init(): Promise<void> {
+        if (!this.isOnCore()) {
+            return; // no-op if this is not a Core workspace
+        }
+        this.componentEntries.forEach(entry => {
+            this.addNewPathMapping(entry);
+        });
+        // update each project under the workspaceRoots
+        for (const workspaceRoot of this.workspaceRoots) {
+            this.updateTSConfigPaths(workspaceRoot);
+        }
+    }
+
+    /**
+     * Given a typescript document, update its containing module's tsconfig.json file's paths attribute.
+     * @param document the specified TS document
+     */
+    public async updateTSConfigFileForDocument(document: TextDocument): Promise<void> {
+        if (!this.isOnCore()) {
+            return; // no-op if this is not a Core workspace
+        }
+        const filePath = URI.file(document.uri).fsPath;
+        this.addNewPathMapping(filePath);
+        const moduleName = this.getModuleName(filePath);
+        const projectRoot = this.getProjectRoot(filePath);
+        const mappings = this.getTSMappingsForModule(moduleName);
+        // add mappings for all imported LWCs
+        const imports = await collectImportsForDocument(document);
+        if (imports.size > 0) {
+            for (const importee of imports) {
+                const isInSameModule = this.doesModuleContainNS(projectRoot, importee.substring(0, importee.indexOf('/')));
+                const tsPath = this.pathMapping.get(importee)?.tsPath;
+                if (tsPath) {
+                    mappings.set(importee, this.getRelativeTSPath(tsPath, isInSameModule));
+                }
+            }
+        }
+        const tsconfigFile = path.join(projectRoot, 'tsconfig.json');
+        this.updateTSConfigFile(tsconfigFile, mappings);
+    }
+
+    /**
+     * Update the tsconfig.json file for one module(project) in core.
+     * Note that this only updates the path for all TypeScript LWCs within the module.
+     * This does not analyze any imported LWCs outside of the module.
+     * @param projectRoot the core module(project)'s root path, e.g., 'core-workspace/core/ui-force-components'
+     */
+    private updateTSConfigPaths(projectRoot: string): void {
+        const tsconfigFile = path.join(projectRoot, 'tsconfig.json');
+        const moduleName = path.basename(projectRoot);
+        const mappings = this.getTSMappingsForModule(moduleName);
+        this.updateTSConfigFile(tsconfigFile, mappings);
+    }
+
+    /**
+     * Update tsconfig.json file with updated mapping.
+     * @param tsconfigFile target tsconfig.json file path
+     * @param mapping updated map that contains path info to update
+     */
+    private async updateTSConfigFile(tsconfigFile: string, mapping: Map<string, string>): Promise<void> {
+        if (!fs.pathExistsSync(tsconfigFile)) {
+            return; // file does not exist, exit early
+        }
+        try {
+            const tsconfigString = await fs.readFile(tsconfigFile, 'utf8');
+            // remove any trailing commas
+            const tsconfig = JSON.parse(tsconfigString.replace(/,([ |\t|\n]+[\}|\]|\)])/g, '$1'));
+            if (tsconfig?.compilerOptions?.paths) {
+                const formattedMapping = new Map<string, string[]>();
+                mapping.forEach((value, key) => {
+                    formattedMapping.set(key, [value]);
+                });
+                const existingPaths = tsconfig.compilerOptions.paths;
+                let updated = false;
+                formattedMapping.forEach((value, key) => {
+                    if (!existingPaths[key] || existingPaths[key][0] !== value[0]) {
+                        updated = true;
+                        existingPaths[key] = value;
+                    }
+                });
+                // only update tsconfig.json if any path mapping is updated
+                if (!updated) {
+                    return;
+                }
+                // sort the path mappings before update the file
+                const sortedKeys = Object.keys(existingPaths).sort();
+                const sortedPaths: Record<string, string[]> = {};
+                sortedKeys.forEach(key => {
+                    sortedPaths[key] = existingPaths[key];
+                });
+                tsconfig.compilerOptions.paths = sortedPaths;
+                fs.writeJSONSync(tsconfigFile, tsconfig, {
+                    spaces: 4,
+                });
+            }
+        } catch (error) {
+            console.warn(`Error updating core tsconfig. Continuing, but may be missing some config. ${error}`);
+        }
+    }
+
+    /**
+     * Get all the path mapping info for a given module name, e.g., 'ui-force-components'.
+     * @param moduleName a target module's name
+     */
+    private getTSMappingsForModule(moduleName: string): Map<string, string> {
+        const mappings = new Map<string, string>();
+        this.pathMapping.forEach((value, key) => {
+            if (value.filePath.includes(moduleName)) {
+                mappings.set(key, this.getRelativeTSPath(value.tsPath, true));
+            }
+        });
+        return mappings;
+    }
+
+    /**
+     * Add a mapping for a TypeScript LWC file path. The file can be .ts or .d.ts.
+     * @param entry file path for a TypeScript LWC ts file,
+     *              e.g., 'core-workspace/core/ui-force-components/modules/force/wireUtils/wireUtils.d.ts'
+     */
+    private addNewPathMapping(entry: string): void {
+        const componentFullName = this.getComponentFullName(entry);
+        const tsPath = this.getTSPath(entry);
+        if (componentFullName && tsPath) {
+            this.pathMapping.set(componentFullName, new TSConfigPathItem({ tsPath, filePath: entry }));
+        }
+    }
+
+    /**
+     * @param entry file path, e.g., 'core-workspace/core/ui-force-components/modules/force/wireUtils/wireUtils.d.ts'
+     * @returns component's full name, e.g., 'force/wireUtils'
+     */
+    private getComponentFullName(entry: string): string {
+        const match = REGEX_PATTERN.exec(entry);
+        return match && match[2] + '/' + match[3];
+    }
+
+    /**
+     * @param entry file path, e.g., 'core-workspace/core/ui-force-components/modules/force/wireUtils/wireUtils.d.ts'
+     * @returns component name, e.g., 'wireUtils'
+     */
+    private getComponentName(entry: string): string {
+        const match = REGEX_PATTERN.exec(entry);
+        return match && match[3];
+    }
+
+    /**
+     * @param entry file path, e.g., 'core-workspace/core/ui-force-components/modules/force/wireUtils/wireUtils.d.ts'
+     * @returns module (project) name, e.g., 'ui-force-components'
+     */
+    private getModuleName(entry: string): string {
+        const match = REGEX_PATTERN.exec(entry);
+        return match && match[1];
+    }
+
+    /**
+     * @param entry file path, e.g., 'core-workspace/core/ui-force-components/modules/force/wireUtils/wireUtils.d.ts'
+     * @returns module (project) name, e.g., 'ui-force-components'
+     */
+    private getProjectRoot(entry: string): string {
+        const moduleName = this.getModuleName(entry);
+        if (moduleName) {
+            return path.join(this.coreRoot, moduleName);
+        }
+    }
+
+    /**
+     * @param entry file path, e.g., 'core-workspace/core/ui-force-components/modules/force/wireUtils/wireUtils.d.ts'
+     * @returns internal representation of a path mapping, e.g., 'ui-force-components/modules/force/wireUtils/wireUtils'
+     */
+    private getTSPath(entry: string): string {
+        const moduleName = this.getModuleName(entry);
+        const componentName = this.getComponentName(entry);
+        const componentFullName = this.getComponentFullName(entry);
+        if (moduleName && componentName && componentFullName) {
+            return `${moduleName}/modules/${componentFullName}/${componentName}`;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param tsPath internal representation of a path mapping, e.g., 'ui-force-components/modules/force/wireUtils/wireUtils'
+     * @param isInSameModule whether this path mapping is used for the same module
+     * @returns a relative path for the mapping in tsconfig.json, e.g., './modules/force/wireUtils/wireUtils'
+     */
+    private getRelativeTSPath(tsPath: string, isInSameModule: boolean): string {
+        return isInSameModule ? './' + tsPath.substring(tsPath.indexOf('/') + 1) : '../' + tsPath;
+    }
+
+    /**
+     * @returns true if this is a core workspace; false otherwise.
+     */
+    private isOnCore(): boolean {
+        return this.workspaceType === WorkspaceType.CORE_ALL || this.workspaceType === WorkspaceType.CORE_PARTIAL;
+    }
+
+    /**
+     * Checks if a given namespace exists in a given module path.
+     */
+    private doesModuleContainNS(modulePath: string, nsName: string): boolean {
+        return fs.pathExistsSync(path.join(modulePath, 'modules', nsName));
+    }
+}

--- a/test-workspaces/core-like-workspace/app/main/core/ui-force-components/modules/force/input-phone/input-phone.ts
+++ b/test-workspaces/core-like-workspace/app/main/core/ui-force-components/modules/force/input-phone/input-phone.ts
@@ -1,0 +1,6 @@
+import { LightningElement, api } from "lwc";
+import { contextLibraryLWC } from 'clients-context-library-lwc';
+
+export default class InputPhone extends LightningElement {
+    @api value;
+}

--- a/test-workspaces/core-like-workspace/app/main/core/ui-global-components/modules/one/app-nav-bar/app-nav-bar.ts
+++ b/test-workspaces/core-like-workspace/app/main/core/ui-global-components/modules/one/app-nav-bar/app-nav-bar.ts
@@ -1,0 +1,4 @@
+import { LightningElement } from 'lwc';
+
+export default class AppNavBar extends LightningElement {
+}

--- a/test-workspaces/core-like-workspace/coreTS/core/tsconfig.json
+++ b/test-workspaces/core-like-workspace/coreTS/core/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "declaration": true,
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "isolatedModules": true,
+        "moduleResolution": "node",
+        "noEmit": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUnusedLocals": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "strictPropertyInitialization": false,
+        "target": "es2020",
+    },
+    "exclude": ["**/node_modules"]
+}

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/clients/context-library-lwc/context-library-lwc.ts
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/clients/context-library-lwc/context-library-lwc.ts
@@ -1,0 +1,3 @@
+export function contextLibraryLWC() {
+    return null;
+}

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone-js/input-phone-js.js
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone-js/input-phone-js.js
@@ -1,0 +1,6 @@
+import { LightningElement, api } from "lwc";
+import { contextLibraryLWC } from "clients/context-library-lwc";
+
+export default class InputPhoneJS extends LightningElement {
+  @api value;
+}

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone/input-phone.html
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone/input-phone.html
@@ -1,0 +1,4 @@
+<template>
+    <div>STUB</div>
+    <input type="text" value={value} />
+</template>

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone/input-phone.ts
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone/input-phone.ts
@@ -1,0 +1,6 @@
+import { LightningElement, api } from "lwc";
+import { contextLibraryLWC } from 'clients-context-library-lwc';
+
+export default class InputPhone extends LightningElement {
+    @api value;
+}

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone/input-phone.ts
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone/input-phone.ts
@@ -1,6 +1,7 @@
 import { LightningElement, api } from "lwc";
-import { contextLibraryLWC } from 'clients-context-library-lwc';
+import { contextLibraryLWC } from "clients-context-library-lwc";
+import AppNavBar from "one/app-nav-bar";
 
 export default class InputPhone extends LightningElement {
-    @api value;
+  @api value;
 }

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone/input-phone.ts
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/modules/force/input-phone/input-phone.ts
@@ -1,5 +1,5 @@
 import { LightningElement, api } from "lwc";
-import { contextLibraryLWC } from "clients-context-library-lwc";
+import { contextLibraryLWC } from "clients/context-library-lwc";
 import AppNavBar from "one/app-nav-bar";
 
 export default class InputPhone extends LightningElement {

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/tsconfig.json
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-force-components/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "paths": {}
+    }
+}

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/modules/one/app-nav-bar/__tests__/app-nav-bar.test.ts
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/modules/one/app-nav-bar/__tests__/app-nav-bar.test.ts
@@ -1,0 +1,5 @@
+describe('app-nav-bar', () => {
+    it('test', () => {
+        expect(2 + 3).toBe(5);
+    });
+});

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/modules/one/app-nav-bar/app-nav-bar.html
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/modules/one/app-nav-bar/app-nav-bar.html
@@ -1,0 +1,4 @@
+<template>
+    <nav class="slds-context-bar__secondary navCenter" role="navigation" aria-label={i18n.globalNav}>
+    </nav>
+</template>

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/modules/one/app-nav-bar/app-nav-bar.ts
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/modules/one/app-nav-bar/app-nav-bar.ts
@@ -1,0 +1,4 @@
+import { LightningElement } from 'lwc';
+
+export default class AppNavBar extends LightningElement {
+}

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/modules/one/app-nav-bar/utils.ts
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/modules/one/app-nav-bar/utils.ts
@@ -1,0 +1,12 @@
+export function debounce(fn, wait) {
+    return function _debounce() {
+        if (!_debounce.pending) {
+            _debounce.pending = true;
+            // eslint-disable-next-line lwc/no-set-timeout
+            setTimeout(() => {
+                fn();
+                _debounce.pending = false;
+            }, wait);
+        }
+    };
+}

--- a/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/tsconfig.json
+++ b/test-workspaces/core-like-workspace/coreTS/core/ui-global-components/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "paths": {}
+    }
+}

--- a/test-workspaces/core-like-workspace/coreTS/core/workspace-user.xml
+++ b/test-workspaces/core-like-workspace/coreTS/core/workspace-user.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?><workspace>
+  <username>un</username>
+  <password>pw</password>
+  <source>
+    <revision>15062234</revision>
+    <branch>main</branch>
+  </source>
+
+  <modules>
+    <module>:core</module>
+    <module>shared-app</module>
+  </modules>
+
+</workspace>


### PR DESCRIPTION
### What does this PR do?

Impact: this PR only has impact on core workspaces for Salesforce internal users working on core. For external users working on SFDX workspaces, this PR should have no impact.

This PR adds a new feature for automatically updating `tsconfig.json`'s `paths` mapping for core workspaces.

LWC team is working on supporting TypeScript for authoring LWCs on core. In order for TypeScript compiler to work with LWC’s folder structure, we need to add a series of `paths` entries in `tsconfig.json` that re-map imports of LWC components to relative file paths of the imported components. For example, if component `one/cmpA` imports `force/wireUtils`, the import statement in `one/cmpA` will be like `import { someUtil } from ‘force/wireUtils’;` and for TypeScript to know where to look for `force/wireUtils` we need to add a path entry in `tsconfig.json` as the following.

```
    "compilerOptions": {
        "paths": {
            "force/wireUtils": ["../ui-force-components/modules/force/wireUtils/wireUtils"],
        }
    }
```

Maintaining this mapping in `tsconfig.json` manually is not convenient and a less ideal DX for developers on core. This PR adds a new indexer in the `lwc-language-server` that maintains a mapping between LWCs and their paths in `tsconfig.json`, automatically updating the `tsconfig.json` file when language server is initialized and whenever a LWC TypeScript file is changed. Thus developers won't need to create entries for `paths` manually when creating new LWCs in TypeScript.

This new feature will update `tsconfig.json` file for the `paths` attribute for all the core modules in the workspace when language server is initialized. Then whenever a LWC TS file is changed, all the imports are analyzed and any necessary LWC imports will be added to `tsconfig.json` automatically.

Here is a short demo [video link](https://drive.google.com/file/d/16JltE0-DKXjblkZqLajuRLRAUOlVxOLX/view) on this feature. In the video, the test workspace `lightning-language-server/test-workspace/core-like-workspace/coreTS/core` (created in this PR) is opened in VSCode, there are two modules `ui-force-components` and `ui-global-components` in the workspace. Both `tsconfig.json` files for them don't have a `paths` entries. After the indexer's init function is executed, both `tsconfig.json` files are updated with the `paths` mappings. After that, if I add an import statement in a ts file, the `tsconfig.json` file is also updated to have the mapping for the new import.

Testing this locally will require this [PR](https://github.com/forcedotcom/salesforcedx-vscode/pull/5423) for adding TS files to file watcher.

### What issues does this PR fix or reference?
@W-14958700@