### PR TITLE
feat: add `tsconfig` and `.ts` file extensions to `.forceignore`

### DIFF
--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -199,7 +199,9 @@ it('configureSfdxProject()', async () => {
     // .forceignore
     const forceignoreContent = fs.readFileSync(forceignorePath, 'utf8');
     expect(forceignoreContent).toContain('**/jsconfig.json');
+    expect(forceignoreContent).toContain('**/tsconfig.json');
     expect(forceignoreContent).toContain('**/.eslintrc.json');
+    expect(forceignoreContent).toContain('**/*.ts');
 
     // typings
     expect(join(sfdxTypingsPath, 'lds.d.ts')).toExist();

--- a/packages/lightning-lsp-common/src/context.ts
+++ b/packages/lightning-lsp-common/src/context.ts
@@ -557,7 +557,9 @@ export class WorkspaceContext {
 
     private async updateForceIgnoreFile(ignoreFile: string): Promise<void> {
         await utils.appendLineIfMissing(ignoreFile, '**/jsconfig.json');
+        await utils.appendLineIfMissing(ignoreFile, '**/tsconfig.json');
         await utils.appendLineIfMissing(ignoreFile, '**/.eslintrc.json');
+        await utils.appendLineIfMissing(ignoreFile, '**/*.ts');
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?
This PR adds `tsconfig.json` and `.ts` file extensions to the `.forceignore` file.

### What issues does this PR fix or reference?
@W-15577958@