### PR TITLE
test: pin ci to node v18

### DIFF
--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version-file: '.nvmrc'
           cache: yarn
       - uses: google/wireit@setup-github-actions-caching/v1
       - name: Cache node modules


### PR DESCRIPTION
### What does this PR do?

This PR temporarily fixes #592 for GHA tests.

Pinning the version of Node in the CI to node v18 for now to unblock other PRs.

