### PR TITLE
feat: automatically update `tsconfig.sfdx.json`'s paths 

### DIFF
--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -352,6 +352,7 @@ it('configureProjectForTs()', async () => {
     const baseTsConfigForceAppContent = fs.readJsonSync(baseTsconfigPathForceApp);
     expect(baseTsConfigForceAppContent).toEqual({
         compilerOptions: {
+            skipLibCheck: true,
             target: 'ESNext',
             paths: {
                 'c/*': [],

--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -336,3 +336,41 @@ it('configureCoreAll()', async () => {
     // const launchContent = fs.readFileSync(launchPath, 'utf8');
     // expect(launchContent).toContain('"name": "SFDC (attach)"');
 });
+
+it('configureProjectForTs()', async () => {
+    const context = new WorkspaceContext('test-workspaces/sfdx-workspace');
+    const baseTsconfigPathForceApp = 'test-workspaces/sfdx-workspace/.sfdx/tsconfig.sfdx.json';
+    const tsconfigPathForceApp = FORCE_APP_ROOT + '/lwc/tsconfig.json';
+    const tsconfigPathUtils = UTILS_ROOT + '/lwc/tsconfig.json';
+    const tsconfigPathRegisteredEmpty = REGISTERED_EMPTY_FOLDER_ROOT + '/lwc/tsconfig.json';
+    const forceignorePath = 'test-workspaces/sfdx-workspace/.forceignore';
+
+    // configure and verify typings/jsconfig after configuration:
+    await context.configureProjectForTs();
+
+    // verify tsconfig.sfdx.json
+    const baseTsConfigForceAppContent = fs.readJsonSync(baseTsconfigPathForceApp);
+    expect(baseTsConfigForceAppContent).toEqual({
+        compilerOptions: {
+            target: 'ESNext',
+            paths: {
+                'c/*': [],
+            },
+        },
+    });
+
+    //verify newly create tsconfig.json
+    const tsconfigForceAppContent = fs.readJsonSync(tsconfigPathForceApp);
+    expect(tsconfigForceAppContent).toEqual({
+        extends: '../../../../.sfdx/tsconfig.sfdx.json',
+        include: ['**/*.ts', '../../../../.sfdx/typings/lwc/**/*.d.ts'],
+        exclude: ['**/__tests__/**'],
+    });
+
+    // clean up artifacts
+    fs.removeSync(baseTsconfigPathForceApp);
+    fs.removeSync(tsconfigPathForceApp);
+    fs.removeSync(tsconfigPathUtils);
+    fs.removeSync(tsconfigPathRegisteredEmpty);
+    fs.removeSync(forceignorePath);
+});

--- a/packages/lightning-lsp-common/src/context.ts
+++ b/packages/lightning-lsp-common/src/context.ts
@@ -658,4 +658,8 @@ export class WorkspaceContext {
         }
         return roots;
     }
+
+    public async updateNamespaceRootTypeCache(): Promise<void> {
+        this.findNamespaceRootsUsingTypeCache = utils.memoize(this.findNamespaceRootsUsingType.bind(this));
+    }
 }

--- a/packages/lightning-lsp-common/src/resources/sfdx/tsconfig-sfdx.base.json
+++ b/packages/lightning-lsp-common/src/resources/sfdx/tsconfig-sfdx.base.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "paths": {
+            "c/*": []
+        }
+    }
+}

--- a/packages/lightning-lsp-common/src/resources/sfdx/tsconfig-sfdx.base.json
+++ b/packages/lightning-lsp-common/src/resources/sfdx/tsconfig-sfdx.base.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "skipLibCheck": true,
         "target": "ESNext",
         "paths": {
             "c/*": []

--- a/packages/lightning-lsp-common/src/resources/sfdx/tsconfig-sfdx.json
+++ b/packages/lightning-lsp-common/src/resources/sfdx/tsconfig-sfdx.json
@@ -1,0 +1,10 @@
+{
+    "extends": "${project_root}/.sfdx/tsconfig.sfdx.json",
+    "include": [
+        "**/*.ts",
+        "${project_root}/.sfdx/typings/lwc/**/*.d.ts"
+    ],
+    "exclude": [
+        "**/__tests__/**"
+    ]
+}

--- a/packages/lightning-lsp-common/src/utils.ts
+++ b/packages/lightning-lsp-common/src/utils.ts
@@ -4,7 +4,7 @@ import { TextDocument, FileEvent, FileChangeType } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import equal from 'deep-equal';
 import { WorkspaceContext } from './context';
-import { WorkspaceType, isLWC } from './shared';
+import { WorkspaceType } from './shared';
 import { promisify } from 'util';
 import { Glob } from 'glob';
 import * as jsonc from 'jsonc-parser';

--- a/packages/lightning-lsp-common/src/utils.ts
+++ b/packages/lightning-lsp-common/src/utils.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import { basename, extname, join, parse, relative, resolve } from 'path';
+import { basename, extname, join, parse, relative, resolve, dirname } from 'path';
 import { TextDocument, FileEvent, FileChangeType } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import equal from 'deep-equal';
@@ -74,17 +74,22 @@ export async function includesDeletedAuraWatchedDirectory(context: WorkspaceCont
     return false;
 }
 
-export async function includesLwcWatchedComponent(context: WorkspaceContext, changes: FileEvent[]): Promise<boolean> {
+export async function containsDeletedLwcWatchedDirectory(context: WorkspaceContext, changes: FileEvent[]): Promise<boolean> {
     for (const event of changes) {
-        if (event.type !== FileChangeType.Changed) {
-            const insideLwcWatchedDirectory = await isLWCWatchedDirectory(context, event.uri);
-            if (insideLwcWatchedDirectory) {
-                const file = toResolvedPath(event.uri);
-                const { dir, name, ext } = parse(file);
-                // Only update path mapping for newly created lwc modules
-                if (/.*(.ts|.js)$/.test(ext) && dir.endsWith(name)) {
-                    return true;
-                }
+        const insideLwcWatchedDirectory = await isLWCWatchedDirectory(context, event.uri);
+        if (event.type === FileChangeType.Deleted && insideLwcWatchedDirectory) {
+            const { dir, name, ext } = parse(event.uri);
+            const folder = basename(dir);
+            const parentFolder= basename(dirname(dir));
+            if (
+                // LWC component
+                (/.*(.ts|.js)$/.test(ext) && folder === name && parentFolder === 'lwc') || 
+                // Folder deletion, subdirectory of lwc or lwc directory itself
+                // When there is no extension the name is the folder name and 
+                // folder becomes the parent folder
+                // ex: /path/to/some/dir, name => dir, folder => some
+                (!ext && (folder === 'lwc' || name === 'lwc'))) {
+                return true
             }
         }
     }

--- a/packages/lwc-language-server/src/__tests__/component-indexer.test.ts
+++ b/packages/lwc-language-server/src/__tests__/component-indexer.test.ts
@@ -154,7 +154,7 @@ describe('ComponentIndexer', () => {
             });
 
             describe('updateSfdxTsConfigPath', () => {
-                it('updates updates tsconfig.sfdx.json path mapping', async () => {
+                it('updates tsconfig.sfdx.json path mapping', async () => {
                     const tsconfigTemplate = {
                         compilerOptions: {
                             target: 'ESNext',

--- a/packages/lwc-language-server/src/__tests__/component-indexer.test.ts
+++ b/packages/lwc-language-server/src/__tests__/component-indexer.test.ts
@@ -128,24 +128,28 @@ describe('ComponentIndexer', () => {
         });
 
         describe('typescript path mapping', () => {
-            const expectedComponents: string[] = [
-                'force-app/main/default/lwc/*/hello_world',
-                'force-app/main/default/lwc/*/import_relative',
-                'force-app/main/default/lwc/*/index',
-                'force-app/main/default/lwc/*/lightning_datatable_example',
-                'force-app/main/default/lwc/*/lightning_tree_example',
-                'force-app/main/default/lwc/*/todo_item',
-                'force-app/main/default/lwc/*/todo',
-                'force-app/main/default/lwc/*/typescript',
-                'force-app/main/default/lwc/*/utils',
-                'utils/meta/lwc/*/todo_util',
-                'utils/meta/lwc/*/todo_utils',
-            ].map(item => path.join(componentIndexer.workspaceRoot, item));
+            const data = [
+                ['c/hello_world', 'force-app/main/default/lwc/hello_world/hello_world'],
+                ['c/import_relative', 'force-app/main/default/lwc/import_relative/import_relative'],
+                ['c/index', 'force-app/main/default/lwc/index/index'],
+                ['c/lightning_datatable_example', 'force-app/main/default/lwc/lightning_datatable_example/lightning_datatable_example'],
+                ['c/lightning_tree_example', 'force-app/main/default/lwc/lightning_tree_example/lightning_tree_example'],
+                ['c/todo_item', 'force-app/main/default/lwc/todo_item/todo_item'],
+                ['c/todo', 'force-app/main/default/lwc/todo/todo'],
+                ['c/typescript', 'force-app/main/default/lwc/typescript/typescript'],
+                ['c/utils', 'force-app/main/default/lwc/utils/utils'],
+                ['c/todo_util', 'utils/meta/lwc/todo_util/todo_util'],
+                ['c/todo_utils', 'utils/meta/lwc/todo_utils/todo_utils'],
+            ].map(([componentName, filePath]) => {
+                const resolvedFilePath = [path.join(componentIndexer.workspaceRoot, filePath)];
+                return [componentName, resolvedFilePath];
+            });
+            const expectedComponents = Object.fromEntries(data);
 
-            describe('#tsConfigPathMappingFiles', () => {
-                it('returns a list of files where the .js or.ts filename is the same as its parent directory name', () => {
-                    const tsConfigPathMapping = componentIndexer.tsConfigPathMappingFiles.sort();
-                    expect(tsConfigPathMapping).toEqual(expectedComponents.sort());
+            describe('#tsConfigPathMapping', () => {
+                it('returns a map of files inside an lwc watched directory where the .js or .ts files match the directory name', () => {
+                    const tsConfigPathMapping = componentIndexer.tsConfigPathMapping;
+                    expect(tsConfigPathMapping).toEqual(expectedComponents);
                 });
             });
 
@@ -166,8 +170,8 @@ describe('ComponentIndexer', () => {
                     componentIndexer.updateSfdxTsConfigPath();
 
                     const tsconfig = readJsonSync(sfdxPath);
-                    const tsconfigPathMapping = tsconfig.compilerOptions.paths['c/*'];
-                    expect(tsconfigPathMapping.sort()).toEqual(expectedComponents.sort());
+                    const tsconfigPathMapping = tsconfig.compilerOptions.paths;
+                    expect(tsconfigPathMapping).toEqual(expectedComponents);
 
                     // Clean-up test files
                     removeSync(sfdxPath);

--- a/packages/lwc-language-server/src/__tests__/component-indexer.test.ts
+++ b/packages/lwc-language-server/src/__tests__/component-indexer.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { URI } from 'vscode-uri';
 import { shared } from '@salesforce/lightning-lsp-common';
 import { Stats, Dirent } from 'fs';
+import { readJsonSync, removeSync, writeJsonSync } from 'fs-extra';
 
 const { WorkspaceType } = shared;
 const workspaceRoot: string = path.resolve('../../test-workspaces/sfdx-workspace');
@@ -123,6 +124,54 @@ describe('ComponentIndexer', () => {
         describe('#generateIndex()', () => {
             it('creates Tag objects for all the component JS files', async () => {
                 expect(componentIndexer.tags.size).toBe(8);
+            });
+        });
+
+        describe('typescript path mapping', () => {
+            const expectedComponents: string[] = [
+                'force-app/main/default/lwc/*/hello_world',
+                'force-app/main/default/lwc/*/import_relative',
+                'force-app/main/default/lwc/*/index',
+                'force-app/main/default/lwc/*/lightning_datatable_example',
+                'force-app/main/default/lwc/*/lightning_tree_example',
+                'force-app/main/default/lwc/*/todo_item',
+                'force-app/main/default/lwc/*/todo',
+                'force-app/main/default/lwc/*/typescript',
+                'force-app/main/default/lwc/*/utils',
+                'utils/meta/lwc/*/todo_util',
+                'utils/meta/lwc/*/todo_utils',
+            ].map(item => path.join(componentIndexer.workspaceRoot, item));
+
+            describe('#tsConfigPathMappingFiles', () => {
+                it('returns a list of files where the .js or.ts filename is the same as its parent directory name', () => {
+                    const tsConfigPathMapping = componentIndexer.tsConfigPathMappingFiles.sort();
+                    expect(tsConfigPathMapping).toEqual(expectedComponents.sort());
+                });
+            });
+
+            describe('updateSfdxTsConfigPath', () => {
+                it('updates updates tsconfig.sfdx.json path mapping', async () => {
+                    const tsconfigTemplate = {
+                        compilerOptions: {
+                            target: 'ESNext',
+                            paths: {
+                                // @ts-ignore
+                                'c/*': [],
+                            },
+                        },
+                    };
+                    const sfdxPath = path.resolve('../../test-workspaces/sfdx-workspace/.sfdx/tsconfig.sfdx.json');
+                    writeJsonSync(sfdxPath, tsconfigTemplate);
+
+                    componentIndexer.updateSfdxTsConfigPath();
+
+                    const tsconfig = readJsonSync(sfdxPath);
+                    const tsconfigPathMapping = tsconfig.compilerOptions.paths['c/*'];
+                    expect(tsconfigPathMapping.sort()).toEqual(expectedComponents.sort());
+
+                    // Clean-up test files
+                    removeSync(sfdxPath);
+                });
             });
         });
     });

--- a/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
+++ b/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
@@ -9,6 +9,8 @@ import {
     Hover,
     CompletionParams,
     CompletionTriggerKind,
+    DidChangeWatchedFilesParams,
+    FileChangeType,
 } from 'vscode-languageserver';
 
 import { URI } from 'vscode-uri';
@@ -47,6 +49,7 @@ jest.mock('vscode-languageserver', () => {
                 onInitialized: (): boolean => true,
                 onCompletion: (): boolean => true,
                 onCompletionResolve: (): boolean => true,
+                onDidChangeWatchedFiles: (): boolean => true,
                 onHover: (): boolean => true,
                 onShutdown: (): boolean => true,
                 onDefinition: (): boolean => true,
@@ -334,32 +337,187 @@ describe('handlers', () => {
     });
 
     describe('onInitialized()', () => {
+        const baseTsconfigPath = SFDX_WORKSPACE_ROOT + '/.sfdx/tsconfig.sfdx.json';
+        const getTsConfigPaths = (): string[] => sync(SFDX_WORKSPACE_ROOT + '/**/lwc/tsconfig.json');
+
+        afterEach(async () => {
+            // Clean up after each test run
+            fsExtra.removeSync(baseTsconfigPath);
+            const tsconfigPaths = getTsConfigPaths();
+            tsconfigPaths.forEach(tsconfigPath => fsExtra.removeSync(tsconfigPath));
+            mockTypeScriptSupportConfig = false;
+        });
+
         it('skip tsconfig initialization when salesforcedx-vscode-lwc.preview.typeScriptSupport = false', async () => {
             await server.onInitialize(initializeParams);
             await server.onInitialized();
 
-            const baseTsconfigPath = SFDX_WORKSPACE_ROOT + '/.sfdx/tsconfig.sfdx.json';
-            const tsconfigPaths = sync(SFDX_WORKSPACE_ROOT + '/**/lwc/tsconfig.json');
             expect(fsExtra.existsSync(baseTsconfigPath)).toBe(false);
+            const tsconfigPaths = getTsConfigPaths();
             expect(tsconfigPaths.length).toBe(0);
         });
 
-        it('skip tsconfig initialization when salesforcedx-vscode-lwc.preview.typeScriptSupport = true', async () => {
+        it('initializes tsconfig when salesforcedx-vscode-lwc.preview.typeScriptSupport = true', async () => {
             // Enable feature flag
             mockTypeScriptSupportConfig = true;
             await server.onInitialize(initializeParams);
             await server.onInitialized();
 
-            const baseTsconfigPath = SFDX_WORKSPACE_ROOT + '/.sfdx/tsconfig.sfdx.json';
-            const tsconfigPaths = sync(SFDX_WORKSPACE_ROOT + '/**/lwc/tsconfig.json');
             expect(fsExtra.existsSync(baseTsconfigPath)).toBe(true);
+            const tsconfigPaths = getTsConfigPaths();
             // There are currently 3 lwc subdirectories under SFDX_WORKSPACE_ROOT
             expect(tsconfigPaths.length).toBe(3);
+        });
 
-            // Clean up after test run
+        it('updates tsconfig.sfdx.json path mapping', async () => {
+            // Enable feature flag
+            mockTypeScriptSupportConfig = true;
+            await server.onInitialize(initializeParams);
+            await server.onInitialized();
+
+            const sfdxTsConfig = fsExtra.readJsonSync(baseTsconfigPath);
+            const pathMapping = sfdxTsConfig.compilerOptions.paths['c/*'];
+            expect(pathMapping.length).toEqual(11);
+        });
+    });
+
+    describe('onDidChangeWatchedFiles', () => {
+        const baseTsconfigPath = SFDX_WORKSPACE_ROOT + '/.sfdx/tsconfig.sfdx.json';
+        const watchedFileDir = SFDX_WORKSPACE_ROOT + '/force-app/main/default/lwc/newlyAddedFile';
+
+        const getPathMapping = (): string[] => {
+            const sfdxTsConfig = fsExtra.readJsonSync(baseTsconfigPath);
+            return sfdxTsConfig.compilerOptions.paths['c/*'];
+        };
+
+        beforeEach(() => {
+            mockTypeScriptSupportConfig = true;
+        });
+
+        afterEach(() => {
+            // Clean up after each test run
             fsExtra.removeSync(baseTsconfigPath);
-            await Promise.all(tsconfigPaths.map(tsconfig => fsExtra.remove(tsconfig)));
+            const tsconfigPaths = sync(SFDX_WORKSPACE_ROOT + '/**/lwc/tsconfig.json');
+            tsconfigPaths.forEach(tsconfigPath => fsExtra.removeSync(tsconfigPath));
+            fsExtra.removeSync(watchedFileDir);
             mockTypeScriptSupportConfig = false;
+        });
+
+        ['.js', '.ts'].forEach(ext => {
+            it(`updates tsconfig.sfdx.json path mapping when ${ext} file added`, async () => {
+                // Enable feature flag
+                mockTypeScriptSupportConfig = true;
+                await server.onInitialize(initializeParams);
+                await server.onInitialized();
+
+                const initializedSfdxTsConfig = fsExtra.readJsonSync(baseTsconfigPath);
+                const initializedPathMapping = initializedSfdxTsConfig.compilerOptions.paths['c/*'];
+                expect(initializedPathMapping.length).toEqual(11);
+
+                // Create files after initialized
+                const watchedFilePath = path.resolve(watchedFileDir, `newlyAddedFile${ext}`);
+                fsExtra.createFileSync(watchedFilePath);
+
+                const didChangeWatchedFilesParams: DidChangeWatchedFilesParams = {
+                    changes: [
+                        {
+                            uri: watchedFilePath,
+                            type: FileChangeType.Created,
+                        },
+                    ],
+                };
+
+                await server.onDidChangeWatchedFiles(didChangeWatchedFilesParams);
+                const pathMapping = getPathMapping();
+                // Path mapping updated
+                expect(pathMapping.length).toEqual(12);
+            });
+
+            it(`removes tsconfig.sfdx.json path mapping when ${ext} files removed`, async () => {
+                // Create files before initialized
+                const watchedFilePath = path.resolve(watchedFileDir, `newlyAddedFile${ext}`);
+                fsExtra.createFileSync(watchedFilePath);
+
+                await server.onInitialize(initializeParams);
+                await server.onInitialized();
+
+                const initializedPathMapping = getPathMapping();
+                expect(initializedPathMapping.length).toEqual(12);
+
+                fsExtra.removeSync(watchedFilePath);
+
+                const didChangeWatchedFilesParams: DidChangeWatchedFilesParams = {
+                    changes: [
+                        {
+                            uri: watchedFilePath,
+                            type: FileChangeType.Deleted,
+                        },
+                    ],
+                };
+
+                await server.onDidChangeWatchedFiles(didChangeWatchedFilesParams);
+                const updatedPathMapping = getPathMapping();
+                expect(updatedPathMapping.length).toEqual(11);
+            });
+
+            it(`no updates to tsconfig.sfdx.json path mapping when ${ext} files changed`, async () => {
+                // Create files before initialized
+                const watchedFilePath = path.resolve(watchedFileDir, `newlyAddedFile${ext}`);
+                fsExtra.createFileSync(watchedFilePath);
+
+                await server.onInitialize(initializeParams);
+                await server.onInitialized();
+
+                const initializedPathMapping = getPathMapping();
+                expect(initializedPathMapping.length).toEqual(12);
+
+                fsExtra.removeSync(watchedFilePath);
+
+                const didChangeWatchedFilesParams: DidChangeWatchedFilesParams = {
+                    changes: [
+                        {
+                            uri: watchedFilePath,
+                            type: FileChangeType.Changed,
+                        },
+                    ],
+                };
+
+                await server.onDidChangeWatchedFiles(didChangeWatchedFilesParams);
+                const updatedPathMapping = getPathMapping();
+                expect(updatedPathMapping.length).toEqual(12);
+            });
+        });
+
+        ['.html', '.css', '.js-meta.xml', '.txt'].forEach(ext => {
+            [FileChangeType.Created, FileChangeType.Changed, FileChangeType.Deleted].forEach(type => {
+                it(`no path mapping updates made for ${ext} on ${type} event`, async () => {
+                    const lwcComponentPath = path.resolve(watchedFileDir, `newlyAddedFile.ts`);
+                    const nonJsOrTsFilePath = path.resolve(watchedFileDir, `newlyAddedFile${ext}`);
+                    fsExtra.createFileSync(lwcComponentPath);
+                    fsExtra.createFileSync(nonJsOrTsFilePath);
+
+                    await server.onInitialize(initializeParams);
+                    await server.onInitialized();
+
+                    const initializedPathMapping = getPathMapping();
+                    expect(initializedPathMapping.length).toEqual(12);
+
+                    fsExtra.removeSync(nonJsOrTsFilePath);
+
+                    const didChangeWatchedFilesParams: DidChangeWatchedFilesParams = {
+                        changes: [
+                            {
+                                uri: nonJsOrTsFilePath,
+                                type: type as FileChangeType,
+                            },
+                        ],
+                    };
+
+                    await server.onDidChangeWatchedFiles(didChangeWatchedFilesParams);
+                    const updatedPathMapping = getPathMapping();
+                    expect(updatedPathMapping.length).toEqual(12);
+                });
+            });
         });
     });
 });

--- a/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
+++ b/packages/lwc-language-server/src/__tests__/lwc-server.test.ts
@@ -404,7 +404,7 @@ describe('handlers', () => {
         });
 
         ['.js', '.ts'].forEach(ext => {
-            it(`updates tsconfig.sfdx.json path mapping when ${ext} file added`, async () => {
+            it(`updates tsconfig.sfdx.json path mapping when ${ext} file created`, async () => {
                 // Enable feature flag
                 mockTypeScriptSupportConfig = true;
                 await server.onInitialize(initializeParams);
@@ -433,7 +433,7 @@ describe('handlers', () => {
                 expect(pathMapping.length).toEqual(12);
             });
 
-            it(`removes tsconfig.sfdx.json path mapping when ${ext} files removed`, async () => {
+            it(`removes tsconfig.sfdx.json path mapping when ${ext} files deleted`, async () => {
                 // Create files before initialized
                 const watchedFilePath = path.resolve(watchedFileDir, `newlyAddedFile${ext}`);
                 fsExtra.createFileSync(watchedFilePath);

--- a/packages/lwc-language-server/src/constants.ts
+++ b/packages/lwc-language-server/src/constants.ts
@@ -1,2 +1,5 @@
 export const DIAGNOSTIC_SOURCE = 'lwc';
 export const MAX_32BIT_INTEGER = 2 ** 31 - 1;
+// TODO: Remove once feature reaches GA
+// The config value comes from salesforcedx-vscode/salesforcedx-vscode-lwc
+export const TYPESCRIPT_SUPPORT_SETTING = 'salesforcedx-vscode-lwc.preview.typeScriptSupport';

--- a/packages/lwc-language-server/src/lwc-server.ts
+++ b/packages/lwc-language-server/src/lwc-server.ts
@@ -80,6 +80,7 @@ export default class Server {
 
     constructor() {
         this.connection.onInitialize(this.onInitialize.bind(this));
+        this.connection.onInitialized(this.onInitialized.bind(this));
         this.connection.onCompletion(this.onCompletion.bind(this));
         this.connection.onCompletionResolve(this.onCompletionResolve.bind(this));
         this.connection.onHover(this.onHover.bind(this));
@@ -128,6 +129,15 @@ export default class Server {
                 },
             },
         };
+    }
+
+    async onInitialized(): Promise<void> {
+        // The config value comes from salesforcedx-vscode/salesforcedx-vscode-lwc
+        const hasTsEnabled = await this.connection.workspace.getConfiguration('salesforcedx-vscode-lwc.preview.typeScriptSupport');
+        // TODO: add onDidChangeConfiguration handler to detect changes in config value
+        if (hasTsEnabled) {
+            await this.context.configureProjectForTs();
+        }
     }
 
     async onCompletion(params: CompletionParams): Promise<CompletionList> {

--- a/test-workspaces/sfdx-workspace/force-app/main/default/lwc/typescript/typescript.html
+++ b/test-workspaces/sfdx-workspace/force-app/main/default/lwc/typescript/typescript.html
@@ -1,0 +1,3 @@
+<template>
+    <h1>hello typescript!</h1>
+</template>

--- a/test-workspaces/sfdx-workspace/force-app/main/default/lwc/typescript/typescript.js-meta.xml
+++ b/test-workspaces/sfdx-workspace/force-app/main/default/lwc/typescript/typescript.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <isExposed>true</isExposed>
+</LightningComponentBundle>

--- a/test-workspaces/sfdx-workspace/force-app/main/default/lwc/typescript/typescript.ts
+++ b/test-workspaces/sfdx-workspace/force-app/main/default/lwc/typescript/typescript.ts
@@ -1,0 +1,3 @@
+import { LightningElement } from "lwc";
+
+export default class extends LightningElement {}


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability for the language server to update the `paths` mapping in `tsconfig.sfdx.json`.

The purpose for doing this is to allow TypeScript to determine where to locate an LWC component.

For example:

```js
import Foo from 'c/bar';
...
```

TypeScript doesn't know how to resolve`c/bar` and requires it to be mapped in the `tsconfig.json`, ex:

```js
{
    "compilerOptions": {
        "paths": {
            "c/*": ["/user/some/where/*/bar"]
        }
    }
}
```

The path mapping is updating in 2 scenarios:

1. When the language server first starts.
2. When there is a file change to a js or ts LWC component.

What issues does this PR fix or reference?
@W-15572824@
