### PR TITLE
fix: valid js config file

### DIFF
--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -183,7 +183,7 @@ it('configureSfdxProject()', async () => {
     expect(jsconfigForceApp.compilerOptions.experimentalDecorators).toBe(true);
     expect(jsconfigForceApp.include[0]).toBe('**/*');
     expect(jsconfigForceApp.include[1]).toBe('../../../../.sfdx/typings/lwc/**/*.d.ts');
-    expect(jsconfigForceApp.compilerOptions.baseUrl).toBeUndefined(); // baseUrl/paths set when indexing
+    expect(jsconfigForceApp.compilerOptions.baseUrl).toBeDefined(); // baseUrl/paths set when indexing
     expect(jsconfigForceApp.typeAcquisition).toEqual({ include: ['jest'] });
     // verify updated jsconfig.json
     const jsconfigUtilsContent = fs.readFileSync(jsconfigPathUtils, 'utf8');

--- a/packages/lightning-lsp-common/src/resources/sfdx/jsconfig-sfdx.json
+++ b/packages/lightning-lsp-common/src/resources/sfdx/jsconfig-sfdx.json
@@ -1,16 +1,17 @@
 {
     "compilerOptions": {
-        "experimentalDecorators": true
+        "experimentalDecorators": true,
+        "baseUrl": ".",
+        "paths": {
+            "c/*": [
+                "*"
+            ]
+        }
     },
     "include": [
         "**/*",
         "${project_root}/.sfdx/typings/lwc/**/*.d.ts"
     ],
-    "paths": {
-        "c/*": [
-            "*"
-        ]
-    },
     "typeAcquisition": {
         "include": [
             "jest"


### PR DESCRIPTION
### What does this PR do?
- Moves `paths` property to the right place in jsconfig.json, inside `compilerOptions` 

### What issues does this PR fix or reference?
@W-15374337@
