### PR TITLE
fix(forceignore): only add tsconfig + ts to forceignore for TS projects @W-16625817@ 

### DIFF
--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -199,9 +199,10 @@ it('configureSfdxProject()', async () => {
     // .forceignore
     const forceignoreContent = fs.readFileSync(forceignorePath, 'utf8');
     expect(forceignoreContent).toContain('**/jsconfig.json');
-    expect(forceignoreContent).toContain('**/tsconfig.json');
     expect(forceignoreContent).toContain('**/.eslintrc.json');
-    expect(forceignoreContent).toContain('**/*.ts');
+    // These should only be present for TypeScript projects
+    expect(forceignoreContent).not.toContain('**/tsconfig.json');
+    expect(forceignoreContent).not.toContain('**/*.ts');
 
     // typings
     expect(join(sfdxTypingsPath, 'lds.d.ts')).toExist();
@@ -347,6 +348,11 @@ it('configureProjectForTs()', async () => {
 
     // configure and verify typings/jsconfig after configuration:
     await context.configureProjectForTs();
+
+    // verify forceignore
+    const forceignoreContent = fs.readFileSync(forceignorePath, 'utf8');
+    expect(forceignoreContent).toContain('**/tsconfig.json');
+    expect(forceignoreContent).toContain('**/*.ts');
 
     // verify tsconfig.sfdx.json
     const baseTsConfigForceAppContent = fs.readJsonSync(baseTsconfigPathForceApp);

--- a/packages/lightning-lsp-common/src/__tests__/context.test.ts
+++ b/packages/lightning-lsp-common/src/__tests__/context.test.ts
@@ -358,6 +358,7 @@ it('configureProjectForTs()', async () => {
     const baseTsConfigForceAppContent = fs.readJsonSync(baseTsconfigPathForceApp);
     expect(baseTsConfigForceAppContent).toEqual({
         compilerOptions: {
+            module: 'NodeNext',
             skipLibCheck: true,
             target: 'ESNext',
             paths: {

--- a/packages/lightning-lsp-common/src/context.ts
+++ b/packages/lightning-lsp-common/src/context.ts
@@ -429,7 +429,7 @@ export class WorkspaceContext {
                     const relativeWorkspaceRoot = utils.relativePath(path.dirname(jsConfigPath), this.workspaceRoots[0]);
                     jsConfigContent = this.processTemplate(jsConfigTemplate, { project_root: relativeWorkspaceRoot });
                     this.updateConfigFile(jsConfigPath, jsConfigContent);
-                    await this.updateForceIgnoreFile(forceignore);
+                    await this.updateForceIgnoreFile(forceignore, false);
                 }
                 break;
             case WorkspaceType.CORE_ALL:
@@ -474,7 +474,7 @@ export class WorkspaceContext {
                     const relativeWorkspaceRoot = utils.relativePath(path.dirname(tsConfigPath), this.workspaceRoots[0]);
                     const tsConfigContent = this.processTemplate(tsConfigTemplate, { project_root: relativeWorkspaceRoot });
                     this.updateConfigFile(tsConfigPath, tsConfigContent);
-                    await this.updateForceIgnoreFile(forceignore);
+                    await this.updateForceIgnoreFile(forceignore, true);
                 }
                 break;
         }
@@ -586,11 +586,14 @@ export class WorkspaceContext {
         }
     }
 
-    private async updateForceIgnoreFile(ignoreFile: string): Promise<void> {
+    private async updateForceIgnoreFile(ignoreFile: string, hasTsEnabled: boolean): Promise<void> {
         await utils.appendLineIfMissing(ignoreFile, '**/jsconfig.json');
-        await utils.appendLineIfMissing(ignoreFile, '**/tsconfig.json');
         await utils.appendLineIfMissing(ignoreFile, '**/.eslintrc.json');
-        await utils.appendLineIfMissing(ignoreFile, '**/*.ts');
+        if (hasTsEnabled) {
+            // WJH
+            await utils.appendLineIfMissing(ignoreFile, '**/tsconfig.json');
+            await utils.appendLineIfMissing(ignoreFile, '**/*.ts');
+        }
     }
 
     /**

--- a/packages/lightning-lsp-common/src/resources/sfdx/tsconfig-sfdx.base.json
+++ b/packages/lightning-lsp-common/src/resources/sfdx/tsconfig-sfdx.base.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "skipLibCheck": true,
         "target": "ESNext",
+        "module": "NodeNext",
         "paths": {
             "c/*": []
         }


### PR DESCRIPTION
### What does this PR do?

This PR updates the language server to only add TypeScript-related files to the `.forceignore` if the project has TypeScript support enabled. It also sets an additional option in the base tsconfig that is required for projects to correctly resolve modules.

### What issues does this PR fix or reference?

Fixes https://github.com/forcedotcom/salesforcedx-vscode/issues/5802

@W-16625817@