### PR TITLE
feat: statically bundleable 

### DIFF
--- a/packages/aura-language-server/src/tern-server/__tests__/__snapshots__/ternCompletion.spec.ts.snap
+++ b/packages/aura-language-server/src/tern-server/__tests__/__snapshots__/ternCompletion.spec.ts.snap
@@ -5,8 +5,30 @@ exports[`tern completions 1`] = `
   "isIncomplete": true,
   "items": [
     {
-      "detail": "AuraInstance",
-      "documentation": "#include aura.Aura_export",
+      "detail": "{enqueueAction, error, hasErrors, lastKnownError, test}",
+      "documentation": "@description This, $A, is supposed to be our ONLY window-polluting top-level variable. Everything else in Aura is
+           attached to it.
+
+@namespace
+
+@borrows AuraComponentService#createComponent as $A.createComponent
+@borrows AuraComponentService#createComponents as $A.createComponents
+@borrows AuraComponentService#getComponent as $A.getComponent
+@borrows AuraClientService#enqueueAction as $A.enqueueAction
+@borrows AuraInstance#getRoot as $A.getRoot
+@borrows AuraInstance#getCallback as $A.getCallback
+@borrows AuraInstance#executeHotspot as $A.executeHotspot
+@borrows AuraInstance#get as $A.get
+@borrows AuraInstance#set as $A.set
+@borrows AuraInstance#error as $A.error
+@borrows AuraInstance#log as $A.log
+@borrows AuraInstance#warning as $A.warning
+@borrows AuraInstance#run as $A.run
+@borrows AuraComponentService#newComponentDeprecated as $A.newCmp
+@borrows AuraComponentService#newComponentAsync as $A.newCmpAsync
+@borrows AuraInstance#localizationService as localizationService
+@borrows AuraInstance#util as util
+@borrows AuraInstance#reportError as $A.reportError",
       "kind": 18,
       "label": "$A",
     },
@@ -29,7 +51,7 @@ exports[`tern completions 1`] = `
       "label": "atob",
     },
     {
-      "detail": "AuraInstance",
+      "detail": "{enqueueAction, error, hasErrors, lastKnownError, test}",
       "documentation": "TODO: Remove the legacy 'aura' top-level name.",
       "kind": 18,
       "label": "aura",
@@ -75,6 +97,12 @@ exports[`tern completions 1`] = `
       "documentation": "This property indicates whether the referenced window is closed or not.",
       "kind": 18,
       "label": "closed",
+    },
+    {
+      "detail": "?",
+      "documentation": undefined,
+      "kind": 18,
+      "label": "components",
     },
     {
       "detail": "fn(message: string) -> bool",
@@ -217,10 +245,16 @@ It should be noted that data stored in either localStorage or sessionStorage is 
       "label": "localStorage",
     },
     {
-      "detail": "location|string",
+      "detail": "location",
       "documentation": "Returns a location object with information about the current location of the document. Assigning to the location property changes the current page to the new address.",
       "kind": 18,
       "label": "location",
+    },
+    {
+      "detail": "?",
+      "documentation": undefined,
+      "kind": 18,
+      "label": "message",
     },
     {
       "detail": "{exports}",
@@ -525,6 +559,12 @@ It should be noted that data stored in either localStorage or sessionStorage is 
       "label": "requestAnimationFrame",
     },
     {
+      "detail": "?",
+      "documentation": undefined,
+      "kind": 18,
+      "label": "returnValue",
+    },
+    {
       "detail": "screen",
       "documentation": "Returns a reference to the screen object associated with the window.",
       "kind": 18,
@@ -611,15 +651,21 @@ It should be noted that data stored in either sessionStorage or localStorage is 
       "label": "setTimeout",
     },
     {
+      "detail": "string",
+      "documentation": undefined,
+      "kind": 18,
+      "label": "state",
+    },
+    {
       "detail": "<top>",
       "documentation": "Returns a reference to the topmost window in the window hierarchy.",
       "kind": 18,
       "label": "top",
     },
     {
-      "detail": "fn(?)",
+      "detail": "string",
       "documentation": "The value undefined.",
-      "kind": 3,
+      "kind": 18,
       "label": "undefined",
     },
     {

--- a/packages/aura-language-server/src/tern-server/tern-aura.ts
+++ b/packages/aura-language-server/src/tern-server/tern-aura.ts
@@ -3,7 +3,7 @@ import * as infer from '../tern/lib/infer';
 import * as tern from '../tern/lib/tern';
 import * as walk from 'acorn-walk';
 import * as fs from 'fs';
-import * as path from 'path';
+import defs from './aura_types.json';
 
 const WG_DEFAULT_EXPORT = 95;
 let server: any = {};
@@ -133,12 +133,6 @@ function readFileAsync(filename, c): void {
     readFile(filename).then(function(contents) {
         c(null, contents);
     });
-}
-
-function loadDefs(): void {
-    let defs = fs.readFileSync(path.join(__dirname, 'aura_types.json'), 'utf8');
-    defs = JSON.parse(defs);
-    server.addDefs(defs);
 }
 
 function findAndBindComponent(type, server, cx, infer): void {
@@ -411,7 +405,7 @@ tern.registerPlugin('aura', function(s, options) {
     });
 
     _debug('IDE mode');
-    loadDefs();
+    server.addDefs(defs);
 
     _debug(new Date().toISOString() + ' Done loading!');
 });

--- a/packages/aura-language-server/tsconfig.json
+++ b/packages/aura-language-server/tsconfig.json
@@ -14,7 +14,7 @@
         "noImplicitAny": false,
         "noUnusedParameters": false,
         "noUnusedLocals": false,
-
+        "resolveJsonModule": true,
         "pretty": true,
         "declaration": true,
         "esModuleInterop": true,


### PR DESCRIPTION
### What does this PR do?
vscode [can't bundle aura-ls](
https://github.com/forcedotcom/salesforcedx-vscode/blob/6887fb0b3776d9185089084e70094e53ec9b1b96/packages/salesforcedx-vscode-lightning/esbuild.config.js#L15)
because of some dynamic (runtime) file resolution, so that it's never going to work on the web.

esbuild can do `await import` but only if the path is a static string, not a var.

this removes some dynamicness and makes the paths more bundle friendly

### What issues does this PR fix or reference?
[W18841416](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002GYEryYAH/view)

