### PR TITLE
fix: bump dep versions: W-19665164

### DIFF
--- a/packages/lwc-language-server/package.json
+++ b/packages/lwc-language-server/package.json
@@ -44,7 +44,7 @@
     "vscode-html-languageservice": "^5.5.1",
     "vscode-languageserver": "^5.2.1",
     "vscode-uri": "^2.1.2",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@lwc/old-compiler": "npm:@lwc/compiler@0.34.8",
@@ -53,7 +53,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^20.0.0",
     "@types/normalize-path": "^3.0.2",
-    "@types/xml2js": "^0.4.5",
+    "@types/xml2js": "^0.4.14",
     "babel-types": "^6.26.0",
     "glob": "^7.2.3",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2818,9 +2818,9 @@
   resolved "https://registry.npmjs.org/@types/tmp/-/tmp-0.1.0.tgz"
   integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
 
-"@types/xml2js@^0.4.5":
+"@types/xml2js@^0.4.14":
   version "0.4.14"
-  resolved "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz"
+  resolved "https://registry.yarnpkg.com/@types/xml2js/-/xml2js-0.4.14.tgz#5d462a2a7330345e2309c6b549a183a376de8f9a"
   integrity sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==
   dependencies:
     "@types/node" "*"
@@ -12283,10 +12283,10 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-xml2js@^0.4.23:
-  version "0.4.23"
-  resolved "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+xml2js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"


### PR DESCRIPTION
### What does this PR do?
Should resolve https://github.com/forcedotcom/salesforcedx-vscode/security/dependabot/64

### What issues does this PR fix or reference?
@W-19665164@