### PR TITLE
feat: implement textDocument/documentSymbol for LWC

### DIFF
--- a/packages/lwc-language-server/src/document-symbols.ts
+++ b/packages/lwc-language-server/src/document-symbols.ts
@@ -1,0 +1,83 @@
+import { DocumentSymbol, SymbolKind, Range, Position, TextDocument } from 'vscode-languageserver';
+import { HTMLDocument, Node } from 'vscode-html-languageservice';
+import { compileDocument } from './javascript/compiler';
+import { ClassMember } from '@salesforce/lightning-lsp-common';
+
+const memberRange = (loc: ClassMember['loc']): Range => {
+    if (!loc) {
+        return Range.create(0, 0, 0, 0);
+    }
+    return Range.create(Position.create(loc.start.line - 1, loc.start.column), Position.create(loc.end.line - 1, loc.end.column));
+};
+
+const memberSymbolKind = (member: ClassMember): SymbolKind => {
+    if (member.type === 'method') {
+        return SymbolKind.Method;
+    }
+    if (member.decorator === 'wire') {
+        return SymbolKind.Event;
+    }
+    return SymbolKind.Property;
+};
+
+export const getJsDocumentSymbols = (document: TextDocument): DocumentSymbol[] => {
+    const { metadata } = compileDocument(document);
+    if (!metadata?.classMembers) {
+        return [];
+    }
+
+    const children: DocumentSymbol[] = metadata.classMembers.map((member) => ({
+        name: member.name,
+        detail: member.decorator ? `@${member.decorator}` : '',
+        kind: memberSymbolKind(member),
+        range: memberRange(member.loc),
+        selectionRange: memberRange(member.loc),
+    }));
+
+    const classRange = metadata.declarationLoc ? memberRange(metadata.declarationLoc) : Range.create(0, 0, document.lineCount - 1, 0);
+
+    return [
+        {
+            name: document.uri.split('/').pop()?.replace(/\.js$/, '') || 'default',
+            kind: SymbolKind.Class,
+            range: classRange,
+            selectionRange: classRange,
+            children,
+        },
+    ];
+};
+
+const htmlNodeSymbolKind = (tag: string): SymbolKind => {
+    if (tag === 'template') {
+        return SymbolKind.Module;
+    }
+    if (tag === 'slot') {
+        return SymbolKind.Interface;
+    }
+    if (tag.includes('-')) {
+        return SymbolKind.Class;
+    }
+    return SymbolKind.Field;
+};
+
+const htmlNodeToSymbol = (node: Node, document: TextDocument): DocumentSymbol | null => {
+    if (!node.tag) {
+        return null;
+    }
+
+    const range = Range.create(document.positionAt(node.start), document.positionAt(node.end));
+    const selectionRange = Range.create(document.positionAt(node.start), document.positionAt(node.startTagEnd ?? node.end));
+
+    const children: DocumentSymbol[] = (node.children || []).map((child) => htmlNodeToSymbol(child, document)).filter(Boolean);
+
+    return {
+        name: node.tag,
+        kind: htmlNodeSymbolKind(node.tag),
+        range,
+        selectionRange,
+        children,
+    };
+};
+
+export const getHtmlDocumentSymbols = (document: TextDocument, htmlDocument: HTMLDocument): DocumentSymbol[] =>
+    htmlDocument.roots.map((root) => htmlNodeToSymbol(root, document)).filter(Boolean);

--- a/packages/lwc-language-server/src/lwc-server.ts
+++ b/packages/lwc-language-server/src/lwc-server.ts
@@ -14,6 +14,8 @@ import {
     ShowMessageNotification,
     MessageType,
     FileChangeType,
+    DocumentSymbolParams,
+    DocumentSymbol,
 } from 'vscode-languageserver';
 
 import {
@@ -30,6 +32,7 @@ import {
 import { basename, dirname, parse } from 'path';
 
 import { compileDocument as javascriptCompileDocument } from './javascript/compiler';
+import { getJsDocumentSymbols, getHtmlDocumentSymbols } from './document-symbols';
 import { AuraDataProvider } from './aura-data-provider';
 import { LWCDataProvider } from './lwc-data-provider';
 import {
@@ -93,6 +96,7 @@ export default class Server {
         this.connection.onHover(this.onHover.bind(this));
         this.connection.onShutdown(this.onShutdown.bind(this));
         this.connection.onDefinition(this.onDefinition.bind(this));
+        this.connection.onDocumentSymbol(this.onDocumentSymbol.bind(this));
         this.connection.onInitialized(this.onInitialized.bind(this));
         this.connection.onDidChangeWatchedFiles(this.onDidChangeWatchedFiles.bind(this));
 
@@ -131,6 +135,7 @@ export default class Server {
                 },
                 hoverProvider: true,
                 definitionProvider: true,
+                documentSymbolProvider: true,
                 workspace: {
                     workspaceFolders: {
                         supported: true,
@@ -259,6 +264,20 @@ export default class Server {
             return;
         }
         return this.languageService.doHover(doc, position, htmlDoc);
+    }
+
+    async onDocumentSymbol(params: DocumentSymbolParams): Promise<DocumentSymbol[]> {
+        const doc = this.documents.get(params.textDocument.uri);
+        if (!doc) {
+            return [];
+        }
+        if (await this.context.isLWCJavascript(doc)) {
+            return getJsDocumentSymbols(doc);
+        }
+        if (await this.context.isLWCTemplate(doc)) {
+            return getHtmlDocumentSymbols(doc, this.languageService.parseHTMLDocument(doc));
+        }
+        return [];
     }
 
     async onDidChangeContent(changeEvent: any): Promise<void> {


### PR DESCRIPTION
## Summary

Adds `textDocument/documentSymbol` support to the LWC language server, enabling outline views, breadcrumbs, and symbol search (e.g. `Telescope lsp_document_symbols` in Neovim, Outline panel in VS Code).

## What's implemented

**JavaScript files** — Returns a hierarchical `DocumentSymbol[]` tree:
- Top-level: the LWC component class (named after the file)
- Children: all class members (`@api`, `@wire`, `@track` properties and methods) with decorator shown as `detail`

**HTML template files** — Returns a nested symbol tree of all template elements:
- Custom components (`c-*`) → `Class` kind
- `<slot>` → `Interface` kind  
- `<template>` → `Module` kind
- Plain HTML elements → `Field` kind

## Changes

- `packages/lwc-language-server/src/document-symbols.ts` — New file with symbol extraction logic
- `packages/lwc-language-server/src/lwc-server.ts` — Register handler, declare `documentSymbolProvider` capability

## Testing

Tested manually with Neovim's native LSP client against LWC components in an SFDX project. Both JS and HTML files return correct hierarchical symbols.